### PR TITLE
Import the auth plugin package for gcp

### DIFF
--- a/cli/pkg/clicontext/config.go
+++ b/cli/pkg/clicontext/config.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd"


### PR DESCRIPTION
The auth plugin package for GCP isn't included not allowing Rio to be installed to GKE clusters. #234 

Vendor packaging needs to be updated - unsure if this should be done as part of commit. 

