### PR TITLE
Honor multipath KUBECONFIG environment

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -115,7 +115,6 @@ func main() {
 		cli.StringFlag{
 			Name:        "kubeconfig",
 			Usage:       "Kubeconfig file to use",
-			EnvVar:      "KUBECONFIG",
 			Destination: &cfg.Kubeconfig,
 		},
 		cli.BoolFlag{

--- a/cli/pkg/clicontext/config.go
+++ b/cli/pkg/clicontext/config.go
@@ -79,10 +79,16 @@ func (c *Config) Validate() error {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	c.findKubeConfig()
+	var cfgOverrides *clientcmd.ClientConfigLoadingRules
+	if c.Kubeconfig == "" && os.Getenv("KUBECONFIG") != "" {
+		cfgOverrides = clientcmd.NewDefaultClientConfigLoadingRules()
+	} else {
+		c.findKubeConfig()
+		cfgOverrides = &clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Kubeconfig}
+	}
 
 	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Kubeconfig},
+		cfgOverrides,
 		&clientcmd.ConfigOverrides{
 			ClusterInfo: clientcmdapi.Cluster{Server: ""},
 			Context: clientcmdapi.Context{


### PR DESCRIPTION
Multipath `KUBECONFIG` environment fails:

```
$ rio ps
no config found
...
```
This can be pretty confusing.

This PR aims at a better configuration handling. Personally, I think `c.findKubeConfig()` is still a a bit confusing and we should probably stay as close to `kubectl` behavior as possible.