### PR TITLE
Update README to mention alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Rio
+# Rio [Alpha]
 
 Rio is a MicroPaaS that can be layered on top of any standard Kubernetes cluster. Consisting of a few Kubernetes custom resources and a CLI to enhance the user experience, users can easily deploy services to Kubernetes and automatically get continuous delivery, DNS, HTTPS, routing, monitoring, autoscaling, canary deployments, git-triggered builds, and much more. All it takes to get going is an existing Kubernetes cluster and the rio CLI.
+
+Rio is currently in Alpha.
 
 ## Quick Start
 


### PR DESCRIPTION
Updates README.md to mention that Rio is in alpha so it's more clear to end-users.