### PR TITLE
revision -q fix

### DIFF
--- a/cli/cmd/revision/revision.go
+++ b/cli/cmd/revision/revision.go
@@ -72,7 +72,7 @@ func Revisions(ctx *clicontext.CLIContext) error {
 				service.Spec.Weight = appObj.Status.RevisionWeight[rev.Version].Weight
 				app, version := services.AppAndVersion(service)
 				output = append(output, ServiceData{
-					Name:    fmt.Sprintf("%s/%s", service.Namespace, app),
+					Name:    fmt.Sprintf("%s/%s:%s", service.Namespace, app, version),
 					Service: service,
 					Pods:    m[fmt.Sprintf("%s/%s/%s", service.Namespace, app, version)],
 				})
@@ -106,7 +106,7 @@ func Revisions(ctx *clicontext.CLIContext) error {
 				service.Spec.Weight = app.Status.RevisionWeight[rev.Version].Weight
 				appName, version := services.AppAndVersion(service)
 				output = append(output, ServiceData{
-					Name:    fmt.Sprintf("%s/%s", service.Namespace, app),
+					Name:    fmt.Sprintf("%s/%s:%s", service.Namespace, appName, version),
 					Service: service,
 					Pods:    m[fmt.Sprintf("%s/%s/%s", app.Namespace, appName, version)],
 				})

--- a/cli/cmd/revision/revision.go
+++ b/cli/cmd/revision/revision.go
@@ -32,6 +32,7 @@ func (r *Revision) Run(ctx *clicontext.CLIContext) error {
 }
 
 type ServiceData struct {
+	Name    string
 	Service *riov1.Service
 	Pods    []v1.Pod
 }
@@ -71,6 +72,7 @@ func Revisions(ctx *clicontext.CLIContext) error {
 				service.Spec.Weight = appObj.Status.RevisionWeight[rev.Version].Weight
 				app, version := services.AppAndVersion(service)
 				output = append(output, ServiceData{
+					Name:    fmt.Sprintf("%s/%s", service.Namespace, app),
 					Service: service,
 					Pods:    m[fmt.Sprintf("%s/%s/%s", service.Namespace, app, version)],
 				})
@@ -104,6 +106,7 @@ func Revisions(ctx *clicontext.CLIContext) error {
 				service.Spec.Weight = app.Status.RevisionWeight[rev.Version].Weight
 				appName, version := services.AppAndVersion(service)
 				output = append(output, ServiceData{
+					Name:    fmt.Sprintf("%s/%s", service.Namespace, app),
 					Service: service,
 					Pods:    m[fmt.Sprintf("%s/%s/%s", app.Namespace, appName, version)],
 				})


### PR DESCRIPTION
Fixes #413 
Matched default formatting to rio ps -q format (< ns >/< app-name >:< version >)

```
PS C:\Users\charm\go\src\github.com\charm-jp\rio\bin> .\rio.exe ps -q
default/demo1
```
```
PS C:\Users\charm\go\src\github.com\charm-jp\rio\bin> .\rio.exe revision
NAME               IMAGE                    CREATED          SCALE     ENDPOINT                                    WEIGHT    DETAIL
default/demo1:v3   ibuildthecloud/demo:v3   15 minutes ago   1         https://demo1-v3-default.7u4m7x.on-rio.io   0
default/demo1:v0   ibuildthecloud/demo:v1   16 minutes ago   1         https://demo1-v0-default.7u4m7x.on-rio.io   100
```
```
PS C:\Users\charm\go\src\github.com\charm-jp\rio\bin> .\rio.exe revision -q
default/demo1:v3
default/demo1:v0
```