### PR TITLE
Edit config with env secret:// or config:// set

### DIFF
--- a/pkg/pretty/stringers/env.go
+++ b/pkg/pretty/stringers/env.go
@@ -41,12 +41,13 @@ func (e *EnvStringer) MaybeString() interface{} {
 	case e.SecretName != "":
 		buf.WriteString("secret://")
 		buf.WriteString(e.SecretName)
+		buf.WriteString("/")
 	case e.ConfigMapName != "":
 		buf.WriteString("config://")
 		buf.WriteString(e.ConfigMapName)
-	default:
-		buf.WriteString(e.Value)
+		buf.WriteString("/")
 	}
+	buf.WriteString(e.Value)
 
 	return buf.String()
 }

--- a/pkg/pretty/stringers/env.go
+++ b/pkg/pretty/stringers/env.go
@@ -37,16 +37,6 @@ func (e *EnvStringer) MaybeString() interface{} {
 	buf := &strings.Builder{}
 	buf.WriteString(e.Name)
 	buf.WriteString("=")
-	switch {
-	case e.SecretName != "":
-		buf.WriteString("secret://")
-		buf.WriteString(e.SecretName)
-		buf.WriteString("/")
-	case e.ConfigMapName != "":
-		buf.WriteString("config://")
-		buf.WriteString(e.ConfigMapName)
-		buf.WriteString("/")
-	}
 	buf.WriteString(e.Value)
 
 	return buf.String()


### PR DESCRIPTION
Fixes #425 

Created secret:
```
apiVersion: v1
kind: Secret
metadata:
  name: test
type: Opaque
data:
  secval: YWRtaW4=
```

Test:
```
rio run -p 80/http --env TEST=secret://test/secval --name demo1 ibuildthecloud/demo:v1
default/demo1:v0
rio.exe edit default/demo1:v0
```

Result Contents:
```
concurrency: 10
env:
- TEST=secret://test/secval
image: ibuildthecloud/demo:v1
imagePullPolicy: IfNotPresent
ports:
- "80"
rollout: true
rolloutIncrement: 5
rolloutInterval: 5
scale: 1-10
weight: 100
```