### PR TITLE
Fix usage of changed flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ rio info
 ```
 
 Note: Rio will use a [service loadbalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) to expose the service mesh gateway.
-If your cluster doesn't support service load balancers, simply run `rio install --host-ports` to use host ports to expose gateway.
+If your cluster doesn't support service load balancers, simply run `rio install --mode hostport` to use host ports to expose gateway.
 
 If your host has multiple IP addresses, you can specify which IP address Rio should use for creating external DNS records with the `--ip-address` flag. For instance to advertise the external IP of an AWS instance: `rio install --ip-address $(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)`
 


### PR DESCRIPTION
The flag `--hostports` seems to have been removed in favour
of `--mode hostport`.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>