### PR TITLE
Ensure registry proxy is starting

### DIFF
--- a/modules/build/feature/feature.go
+++ b/modules/build/feature/feature.go
@@ -58,7 +58,9 @@ func Register(ctx context.Context, rContext *types.Context) error {
 		},
 		OnStart: func(feature *v1.Feature) error {
 			return start.All(ctx, 5,
+				rContext.Global,
 				rContext.Build,
+				rContext.Core,
 				rContext.Webhook,
 			)
 		},


### PR DESCRIPTION
This fixes the _"no available registry endpoint: failed to do request: Head http://localhost:5442"_ error