### PR TITLE
Limit secret list by type

### DIFF
--- a/cli/pkg/clicontext/types.go
+++ b/cli/pkg/clicontext/types.go
@@ -417,6 +417,9 @@ func (c *CLIContext) listNamespace(namespace, typeName string) (ret []runtime.Ob
 		}
 		return ret, err
 	case clitypes.SecretType:
+		opts = metav1.ListOptions{
+			FieldSelector: "type!=kubernetes.io/service-account-token,type!=istio.io/key-and-cert",
+		}
 		objs, err := c.Core.Secrets(namespace).List(opts)
 		for i := range objs.Items {
 			ret = append(ret, &objs.Items[i])


### PR DESCRIPTION
Issue: https://github.com/rancher/rio/issues/422

This assumes that the CLI should never display these types of secrets.

### Testing: 

* Install rio
* run `rio secret` and notice lots of secrets
* use new CLI build with same cluster and notice `rio secret` no longer lists secrets with type `kubernetes.io/service-account-token` or type `istio.io/key-and-cert`