### PR TITLE
Print subcommand help 

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -230,7 +230,15 @@ func main() {
 	}
 	app.ExitErrHandler = func(context *cli.Context, err error) {
 		if err != nil && strings.Contains(err.Error(), clicontext.ErrNoConfig.Error()) {
-			printConfigUsage()
+			if context.Args().Get(context.NArg()-1) == "--help" {
+				err = cli.ShowCommandHelp(context, context.Args().First())
+				if err != nil {
+					cli.HandleExitCoder(err)
+				}
+			} else {
+				printConfigUsage()
+			}
+			os.Exit(0)
 		} else {
 			cli.HandleExitCoder(err)
 		}


### PR DESCRIPTION
This commit add support for printing out the help for a specific
subcommand when a commands matching the form rio SUBCOMMAND --help
are entered.

Addresses https://github.com/rancher/rio/issues/491