### PR TITLE
Use k8s wait method and scale wait times to remove flakiness

### DIFF
--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/namesgenerator"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const testingNamespace = "testing-ns"
@@ -43,33 +44,17 @@ func RioCmd(name string, args []string) (string, error) {
 	return string(stdOutErr), nil
 }
 
-type waitForMe = func() bool
-
-// WaitFor takes a method and waits until it returns true
-func WaitFor(f waitForMe, timeout int) bool {
-	sleepSeconds := 1
-	for start := time.Now(); time.Since(start) < time.Second*time.Duration(timeout); {
-		out := f()
-		if out == true {
-			return out
-		}
-		time.Sleep(time.Second * time.Duration(sleepSeconds))
-		sleepSeconds++
-	}
-	return false
-}
-
 // Wait until a URL has a response that returns 200 status code, else return error
 func WaitForURLResponse(endpoint string) (string, error) {
-	f := func() bool {
+	f := wait.ConditionFunc(func() (bool, error) {
 		_, err := GetURL(endpoint)
 		if err == nil {
-			return true
+			return true, nil
 		}
-		return false
-	}
-	ok := WaitFor(f, 120)
-	if ok == false {
+		return false, nil
+	})
+	err := wait.Poll(2*time.Second, 120*time.Second, f)
+	if err != nil {
 		return "", errors.New("endpoint did not return 200")
 	}
 	resp, _ := GetURL(endpoint)


### PR DESCRIPTION
Follow up to https://github.com/rancher/rio/issues/486 to remove flakiness 

Reuse poll to make life easier: https://godoc.org/k8s.io/apimachinery/pkg/util/wait#Poll