### PR TITLE
Fix bug to allow riofile export to have multiples

### DIFF
--- a/cli/cmd/export/export.go
+++ b/cli/cmd/export/export.go
@@ -101,28 +101,28 @@ func collectObjectsFromNs(ctx *clicontext.CLIContext, ns string) ([]runtime.Obje
 		objects = append(objects, &services.Items[i])
 	}
 
-	for _, svc := range services.Items {
-		configs, err := configmapsFromService(ctx, svc)
+	for i := range services.Items {
+		configs, err := configmapsFromService(ctx, services.Items[i])
 		if err != nil {
 			return objects, err
 		}
 		objects = append(objects, configs...)
 	}
 
-	externalservices, err := ctx.Rio.ExternalServices(ns).List(metav1.ListOptions{})
+	externalServices, err := ctx.Rio.ExternalServices(ns).List(metav1.ListOptions{})
 	if err != nil {
 		return objects, err
 	}
-	for _, obj := range externalservices.Items {
-		objects = append(objects, &obj)
+	for i := range externalServices.Items {
+		objects = append(objects, &externalServices.Items[i])
 	}
 
 	routers, err := ctx.Rio.Routers(ns).List(metav1.ListOptions{})
 	if err != nil {
 		return objects, err
 	}
-	for _, obj := range routers.Items {
-		objects = append(objects, &obj)
+	for i := range routers.Items {
+		objects = append(objects, &routers.Items[i])
 	}
 
 	return objects, nil

--- a/cli/cmd/rm/rm.go
+++ b/cli/cmd/rm/rm.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Rm struct {
-	T_Type string `desc:"delete specific type. Available types: [config,service,router,externalservice,publicdomain,app,secret,build]"`
+	T_Type string `desc:"delete specific type. Available types: [config,service,router,externalservice,publicdomain,app,secret,build,stack]"`
 }
 
 func (r *Rm) Run(ctx *clicontext.CLIContext) error {


### PR DESCRIPTION
Issue: https://github.com/rancher/rio/issues/551

We are adding the memory address of iterator `obj` twice, but then re-setting obj on loop so you get multiple of the same. Fix is to use address of actual value, not the iterator. 

Will add testing for this in the export roundtrip issues. 

Also add stack to rm types in CLI