### PR TITLE
Add roundtrip stack export integration test

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -3,8 +3,19 @@ set -e
 
 cd $(dirname $0)/..
 
+fatal()
+{
+    echo "[ERROR] " "$@"
+    exit 1
+}
+
+
 if [[ ${ARCH} == amd64 ]]; then
     echo Running tests
+
+    if grep -rnw ./tests/integration/ -e "Focus"; then
+      fatal "Integration tests must not be focused"
+    fi
 
     go test -cover -tags=test ./...
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,7 +31,7 @@ Dev Notes
 * We are purposefully failing tests in the util code rather than returning errors in order to keep specs clean
     * Only fail tests in public methods. Public methods should not call each other.
 * To add a new suite, create a file and add it in the TestSuite list
-* While writing use `it.Focus` or `when.Focus` to limit to your spec, just remember to revert
+* While writing use `it.Focus` or `when.Focus` to limit to your spec
 * Use parallel tests as much as possible
 * Most every `It` block spins up a new service which takes > 10 seconds. If you want to specify multiple assertions on a single service it will be much faster to use testify descriptions within a single block, example in run_test.go
 * Ensure all `Remove` functions can be run on a never-instantiated object, you don't know what order will be in `it.After`.  

--- a/tests/integration/export_test.go
+++ b/tests/integration/export_test.go
@@ -11,27 +11,27 @@ import (
 
 func exportTests(t *testing.T, when spec.G, it spec.S) {
 
-	serviceImage := "nginx"
-	var service testutil.TestService
-
-	it.Before(func() {
-		service.Create(t, serviceImage)
-	})
-
-	it.After(func() {
-		service.Remove()
-	})
-
 	when("A service is running and we call export on it", func() {
-		it("should have populated fields in normal format", func() {
-			exportedService := service.Export()
-			assert.Equal(t, serviceImage, exportedService.GetImage(), "should have correct image")
-			assert.Equal(t, 1, exportedService.GetScale(), "should have scale of 1")
+
+		serviceImage := "nginx"
+		var service testutil.TestService
+
+		it.Before(func() {
+			service.Create(t, serviceImage)
 		})
-		it("should have populated fields in raw format", func() {
-			exportedService := service.ExportRaw()
-			assert.Equal(t, serviceImage, exportedService.GetImage(), "should have correct image")
-			assert.Equal(t, 1, exportedService.GetScale(), "should have scale of 1")
+
+		it.After(func() {
+			service.Remove()
+		})
+
+		it("should have correct field data", func() {
+			exportedService := service.Export()
+			assert.Equal(t, serviceImage, exportedService.GetImage(), "should have correct image in standard format")
+			assert.Equal(t, 1, exportedService.GetScale(), "should have scale of 1 in standard format")
+			rawExportedService := service.ExportRaw()
+			assert.Equal(t, serviceImage, rawExportedService.GetImage(), "should have correct image in raw format")
+			assert.Equal(t, 1, rawExportedService.GetScale(), "should have scale of 1 in raw format")
 		})
 	}, spec.Parallel())
+
 }

--- a/tests/integration/fixtures/riofile-export.yaml
+++ b/tests/integration/fixtures/riofile-export.yaml
@@ -1,0 +1,78 @@
+externalservices:
+  es-foo:
+    fqdn: www.example.com
+  es-bar:
+    ipAddresses:
+    - 1.1.1.1
+routers:
+  route-foo:
+    routes:
+    - matches:
+      - path:
+          exact: /v0
+      to:
+      - namespace: testing-ns
+        revision: v0
+        service: export-test-image
+    - matches:
+      - path:
+          exact: /v3
+      to:
+      - namespace: testing-ns
+        revision: v3
+        service: export-test-image
+  route-bar:
+    routes:
+    - matches:
+      - path:
+          exact: /bv0
+      to:
+      - namespace: testing-ns
+        revision: v0
+        service: export-test-build
+services:
+  export-test-image:
+    concurrency: 10
+    image: ibuildthecloud/demo:v1
+    imagePullPolicy: IfNotPresent
+    ports:
+    - "80"
+    rollout: true
+    rolloutIncrement: 5
+    rolloutInterval: 5
+    scale: 1-10
+    version: v0
+    weight: 100
+  export-test-image-v3:
+    app: "export-test-image"
+    concurrency: 10
+    image: ibuildthecloud/demo:v3
+    imagePullPolicy: IfNotPresent
+    ports:
+      - "80"
+    rollout: true
+    rolloutIncrement: 5
+    rolloutInterval: 5
+    scale: 1-10
+    version: v3
+    weight: 100
+  export-test-build:
+    build:
+      BuildTimeout: null
+      branch: master
+      buildContext: .
+      dockerFile: Dockerfile
+      dockerFilePath: .
+      repo: https://github.com/rancher/rio-demo
+      template: buildkit
+    concurrency: 10
+    image: localhost:5442/testing-ns-export-test-build:19bc3ddfe17fb058163871dc48e07521397422bd
+    imagePullPolicy: IfNotPresent
+    ports:
+    - 80:8080
+    rollout: true
+    rolloutIncrement: 5
+    rolloutInterval: 5
+    scale: 1-10
+    version: v0
+    weight: 100

--- a/tests/integration/riofile_test.go
+++ b/tests/integration/riofile_test.go
@@ -1,0 +1,48 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher/rio/tests/testutil"
+)
+
+func riofileTests(t *testing.T, when spec.G, it spec.S) {
+
+	when("A riofile is imported", func() {
+
+		var riofile testutil.TestRiofile
+
+		it.Before(func() {
+			riofile.Up(t, "riofile-export.yaml")
+		})
+
+		it.After(func() {
+			riofile.Remove()
+		})
+
+		it("should correctly build the system", func() {
+			// Export check
+			assert.Equal(t, riofile.Readfile(), riofile.ExportStack(), "should have stack export be same as original file")
+			// external services
+			externalFoo := testutil.GetExternalService(t, "es-foo")
+			assert.Equal(t, "www.example.com", externalFoo.GetFQDN(), "should have external service with fqdn")
+			externalBar := testutil.GetExternalService(t, "es-bar")
+			assert.Equal(t, "1.1.1.1", externalBar.GetFirstIPAddress(), "should have external service with ip")
+			// services and their endpoints
+			serviceV0 := testutil.GetService(t, "export-test-image", "v0")
+			serviceV3 := testutil.GetService(t, "export-test-image", "v3")
+			assert.Equal(t, serviceV0.GetEndpoint(), "Hello World", "should have service v0 with endpoint")
+			assert.Equal(t, serviceV3.GetEndpoint(), "Hello World v3", "should have service v3 with endpoint")
+			// routers and their endpoints
+			routerBar := testutil.GetRoute(t, "route-bar", "/bv0")
+			assert.Equal(t, "/bv0", routerBar.Router.Spec.Routes[0].Matches[0].Path.Exact, "should have correct route set")
+			routerFooV0 := testutil.GetRoute(t, "route-foo", "/v0")
+			routerFooV3 := testutil.GetRoute(t, "route-foo", "/v3")
+			assert.Equal(t, "Hello World", routerFooV0.GetEndpoint(), "should have working route paths for v1")
+			assert.Equal(t, "Hello World v3", routerFooV3.GetEndpoint(), "should have working route paths for v3")
+		})
+	}, spec.Parallel())
+}

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -27,6 +27,7 @@ func TestSuite(t *testing.T) {
 		"config":          configTests,
 		"export":          exportTests,
 		"externalService": externalServiceTests,
+		"riofile":         riofileTests,
 	}
 	for desc, fnc := range specs {
 		suite(desc, fnc)

--- a/tests/testutil/config.go
+++ b/tests/testutil/config.go
@@ -32,8 +32,7 @@ func (tc *TestConfig) Create(t *testing.T, content []string) {
 	if err != nil {
 		tc.T.Fatal(err.Error())
 	}
-	args := []string{"create", tc.Name, tc.Filepath}
-	_, err = RioCmd("config", args)
+	_, err = RioCmd([]string{"config", "create", tc.Name, tc.Filepath})
 	if err != nil {
 		tc.T.Fatalf("config create command failed: %v", err.Error())
 	}
@@ -46,7 +45,7 @@ func (tc *TestConfig) Create(t *testing.T, content []string) {
 // Executes "rio rm" for this config
 func (tc *TestConfig) Remove() {
 	if tc.ConfigMap.Name != "" {
-		_, err := RioCmd("rm", []string{"--type", "config", tc.Name})
+		_, err := RioCmd([]string{"rm", "--type", "config", tc.Name})
 		if err != nil {
 			tc.T.Logf("failed to delete config: %v", err.Error())
 		}
@@ -97,8 +96,7 @@ func (tc *TestConfig) createTempFile(filename string, content []string) error {
 }
 
 func (tc *TestConfig) reload() error {
-	args := append([]string{"--type", "config", "--format", "json", tc.Name})
-	out, err := RioCmd("inspect", args)
+	out, err := RioCmd([]string{"inspect", "--type", "config", "--format", "json", tc.Name})
 	if err != nil {
 		return err
 	}

--- a/tests/testutil/externalservice.go
+++ b/tests/testutil/externalservice.go
@@ -25,8 +25,7 @@ func (es *TestExternalService) Create(t *testing.T, target string) {
 	es.T = t
 	es.Target = target
 	es.Name = fmt.Sprintf("%s/%s", testingNamespace, GenerateName())
-	args := []string{"create", es.Name, target}
-	_, err := RioCmd("externalservice", args)
+	_, err := RioCmd([]string{"externalservice", "create", es.Name, target})
 	if err != nil {
 		es.T.Fatalf("external service create command failed: %v", err.Error())
 	}
@@ -36,10 +35,25 @@ func (es *TestExternalService) Create(t *testing.T, target string) {
 	}
 }
 
+// Takes the name of an existing external service, loads it, and returns
+func GetExternalService(t *testing.T, name string) TestExternalService {
+	es := TestExternalService{
+		Target:          "",
+		Name:            fmt.Sprintf("%s/%s", testingNamespace, name),
+		ExternalService: riov1.ExternalService{},
+		T:               t,
+	}
+	err := es.waitForExternalService()
+	if err != nil {
+		es.T.Fatalf(err.Error())
+	}
+	return es
+}
+
 // Executes "rio rm" for this external service
 func (es *TestExternalService) Remove() {
 	if es.ExternalService.Name != "" {
-		_, err := RioCmd("rm", []string{"--type", "externalservice", es.Name})
+		_, err := RioCmd([]string{"rm", "--type", "externalservice", es.Name})
 		if err != nil {
 			es.T.Logf("failed to delete external service: %v", err.Error())
 		}
@@ -63,8 +77,7 @@ func (es *TestExternalService) GetFQDN() string {
 //////////////////
 
 func (es *TestExternalService) reload() error {
-	args := append([]string{"--type", "externalservice", "--format", "json", es.Name})
-	out, err := RioCmd("inspect", args)
+	out, err := RioCmd([]string{"inspect", "--type", "externalservice", "--format", "json", es.Name})
 	if err != nil {
 		return err
 	}

--- a/tests/testutil/publicdomain.go
+++ b/tests/testutil/publicdomain.go
@@ -30,8 +30,7 @@ func (td *TestDomain) RegisterDomain(t *testing.T, domain string, target string)
 	td.GeneratedDomainName = fmt.Sprintf("%v/%v",
 		testingNamespace,
 		strings.Replace(domain, ".", "-", 1))
-	args := []string{"register", domain, target}
-	_, err := RioCmd("domain", args)
+	_, err := RioCmd([]string{"domain", "register", domain, target})
 	if err != nil {
 		td.T.Fatalf("register domain command failed: %v", err.Error())
 	}
@@ -44,7 +43,7 @@ func (td *TestDomain) RegisterDomain(t *testing.T, domain string, target string)
 // Executes "rio domain unregister" for this domain
 func (td *TestDomain) UnRegister() {
 	if td.PublicDomain.Spec.DomainName != "" {
-		_, err := RioCmd("domain", []string{"unregister", td.GeneratedDomainName})
+		_, err := RioCmd([]string{"domain", "unregister", td.GeneratedDomainName})
 		if err != nil {
 			td.T.Logf("failed to unregister domain:  %v", err.Error())
 		}
@@ -68,8 +67,7 @@ func (td *TestDomain) GetDomain() string {
 //////////////////
 
 func (td *TestDomain) reload() error {
-	args := append([]string{"--type", "publicdomain", "--format", "json"}, td.GeneratedDomainName)
-	out, err := RioCmd("inspect", args)
+	out, err := RioCmd([]string{"inspect", "--type", "publicdomain", "--format", "json", td.GeneratedDomainName})
 	if err != nil {
 		return err
 	}

--- a/tests/testutil/riofile.go
+++ b/tests/testutil/riofile.go
@@ -1,0 +1,110 @@
+package testutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	riov1 "github.com/rancher/rio/pkg/apis/rio.cattle.io/v1"
+)
+
+type TestRiofile struct {
+	Name     string
+	Filepath string
+	Stack    riov1.Stack
+	T        *testing.T
+}
+
+// Bring up a riofile by fixture file
+func (trf *TestRiofile) Up(t *testing.T, filename string) {
+	trf.T = t
+	stackName := RandomString(5)
+	trf.Name = fmt.Sprintf("%s/%s", testingNamespace, stackName)
+	pwd, err := os.Getwd()
+	if err != nil {
+		trf.T.Fatal(err)
+	}
+	if !strings.Contains(pwd, "tests/") {
+		pwd = pwd + "/tests/integration" // hack for running tests in package dir
+	}
+	trf.Filepath = fmt.Sprintf("%s/fixtures/%s", pwd, filename)
+	_, err = RioCmd([]string{"--namespace", testingNamespace, "up", "--name", stackName, "-f", trf.Filepath})
+	if err != nil {
+		trf.T.Fatalf("Failed to create stack:  %v", err.Error())
+	}
+	err = trf.waitForStack()
+	if err != nil {
+		trf.T.Fatalf(err.Error())
+	}
+}
+
+// Remove a stack and its objects
+// todo: use owner-name annotation to remove orphaned objects (potentially in pkg) if we continue to see them
+func (trf *TestRiofile) Remove() {
+	_, err := RioCmd([]string{"rm", "--type", "stack", trf.Name})
+	if err != nil {
+		trf.T.Log(err.Error())
+	}
+}
+
+// Return "rio export --stack {name}" as string
+func (trf *TestRiofile) ExportStack() string {
+	out, err := RioCmd([]string{"export", "--stack", trf.Name})
+	if err != nil {
+		trf.T.Log(err.Error())
+	}
+	return strings.TrimSuffix(out, "\n")
+}
+
+// Returns raw Riofile as string
+func (trf *TestRiofile) Readfile() string {
+	contents, err := ioutil.ReadFile(trf.Filepath)
+	if err != nil {
+		trf.T.Log(err.Error())
+	}
+	return strings.TrimSuffix(string(contents), "\n")
+}
+
+//////////////////
+// Private methods
+//////////////////
+
+// reload calls inspect on the stack and uses that to reload our object
+func (trf *TestRiofile) reload() error {
+	out, err := RioCmd([]string{"inspect", "--type", "stack", "--format", "json", trf.Name})
+	if err != nil {
+		return err
+	}
+	trf.Stack = riov1.Stack{}
+	if err := json.Unmarshal([]byte(out), &trf.Stack); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Wait for a stack to be deployed, does not wait for stack objects
+func (trf *TestRiofile) waitForStack() error {
+	f := wait.ConditionFunc(func() (bool, error) {
+		err := trf.reload()
+		if err == nil {
+			for _, con := range trf.Stack.Status.Conditions {
+				if con.Type == "DeployedStackRiofile" && con.Status == "True" {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+	err := wait.Poll(2*time.Second, 60*time.Second, f)
+	if err != nil {
+		return errors.New("stack not successfully initiated")
+	}
+	return nil
+}

--- a/tests/testutil/router.go
+++ b/tests/testutil/router.go
@@ -28,8 +28,7 @@ func (tr *TestRoute) Add(t *testing.T, routePath string, action string, target T
 	tr.Path = routePath
 	tr.Name = fmt.Sprintf("%s/%s", testingNamespace, fakeDomain)
 	route := fmt.Sprintf("%s.%s%s", fakeDomain, testingNamespace, routePath)
-	args := []string{"add", route, action, target.Name}
-	_, err := RioCmd("route", args)
+	_, err := RioCmd([]string{"route", "add", route, action, target.Name})
 	if err != nil {
 		tr.T.Fatalf("route add command failed:  %v", err.Error())
 	}
@@ -39,10 +38,25 @@ func (tr *TestRoute) Add(t *testing.T, routePath string, action string, target T
 	}
 }
 
+// Takes name of existing router and returns it as a TestRoute
+func GetRoute(t *testing.T, name string, routePath string) TestRoute {
+	tr := TestRoute{
+		Router: riov1.Router{},
+		Name:   fmt.Sprintf("%s/%s", testingNamespace, name),
+		Path:   routePath,
+		T:      t,
+	}
+	err := tr.waitForRoute()
+	if err != nil {
+		tr.T.Fatalf(err.Error())
+	}
+	return tr
+}
+
 // Executes "rio rm" for this route. This will delete all routes under this domain.
 func (tr *TestRoute) Remove() {
 	if tr.Router.Name != "" {
-		_, err := RioCmd("rm", []string{"--type", "router", tr.Name})
+		_, err := RioCmd([]string{"rm", "--type", "router", tr.Name})
 		if err != nil {
 			tr.T.Logf("failed to delete route:  %v", err.Error())
 		}
@@ -67,8 +81,7 @@ func (tr *TestRoute) GetEndpoint() string {
 //////////////////
 
 func (tr *TestRoute) reload() error {
-	args := append([]string{"--type", "router", "--format", "json", tr.Name})
-	out, err := RioCmd("inspect", args)
+	out, err := RioCmd([]string{"inspect", "--type", "router", "--format", "json", tr.Name})
 	if err != nil {
 		return err
 	}

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -33,9 +33,8 @@ func PreCheck() {
 }
 
 // RioCmd executes rio CLI commands with your arguments
-// Example: name=run and args=["-n", "test", "nginx"] would run: "rio run -n test nginx"
-func RioCmd(name string, args []string) (string, error) {
-	args = append([]string{name}, args...) // named command is always first arg
+// Example: args=["run", "-n", "test", "nginx"] would run: "rio run -n test nginx"
+func RioCmd(args []string) (string, error) {
 	cmd := exec.Command("rio", args...)
 	stdOutErr, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Issue: https://github.com/rancher/rio/issues/532

This PR does multiple things: 
* Add roundtrip integration tests for riofile including endpoint checks and export checks
* Convert RioCMD signature arguments to a single slice. 
* Fail any CI run that includes `.Focus()`