### PR TITLE
Adding extra validations using kubectl for service endpoints

### DIFF
--- a/tests/integration/endpoint_test.go
+++ b/tests/integration/endpoint_test.go
@@ -14,6 +14,9 @@ func endpointTests(t *testing.T, when spec.G, it spec.S) {
 	var service testutil.TestService
 	var stagedService testutil.TestService
 
+	it.Before(func() {
+		service.Create(t, "ibuildthecloud/demo:v1")
+	})
 	it.After(func() {
 		service.Remove()
 		stagedService.Remove()
@@ -21,10 +24,29 @@ func endpointTests(t *testing.T, when spec.G, it spec.S) {
 
 	when("a service is running and another is staged", func() {
 		it("should have endpoints that are available on both", func() {
-			service.Create(t, "ibuildthecloud/demo:v1")
 			stagedService = service.Stage("ibuildthecloud/demo:v3", "v3")
-			assert.Equal(t, "Hello World", service.GetEndpoint())
-			assert.Equal(t, "Hello World v3", stagedService.GetEndpoint())
+
+			// Check the hostnames returned by Rio and Kubectl are equal
+			assert.Equal(t,
+				testutil.GetHostname(service.GetKubeEndpointURL()),
+				testutil.GetHostname(service.GetEndpointURL()),
+			)
+			assert.Equal(t,
+				testutil.GetHostname(stagedService.GetKubeEndpointURL()),
+				testutil.GetHostname(stagedService.GetEndpointURL()),
+			)
+
+			assert.Equal(t, "Hello World", service.GetEndpointResponse())
+			assert.Equal(t, "Hello World v3", stagedService.GetEndpointResponse())
+		})
+		it("should have the service app endpoint properly created", func() {
+
+			// Check the hostnames returned by Rio and Kubectl are equal
+			assert.Equal(t,
+				testutil.GetHostname(service.GetKubeAppEndpointURL()),
+				testutil.GetHostname(service.GetAppEndpointURL()),
+			)
+			assert.Equal(t, "Hello World", service.GetAppEndpointResponse())
 		})
 	}, spec.Parallel())
 }

--- a/tests/integration/riofile_test.go
+++ b/tests/integration/riofile_test.go
@@ -34,8 +34,8 @@ func riofileTests(t *testing.T, when spec.G, it spec.S) {
 			// services and their endpoints
 			serviceV0 := testutil.GetService(t, "export-test-image", "v0")
 			serviceV3 := testutil.GetService(t, "export-test-image", "v3")
-			assert.Equal(t, serviceV0.GetEndpoint(), "Hello World", "should have service v0 with endpoint")
-			assert.Equal(t, serviceV3.GetEndpoint(), "Hello World v3", "should have service v3 with endpoint")
+			assert.Equal(t, serviceV0.GetEndpointResponse(), "Hello World", "should have service v0 with endpoint")
+			assert.Equal(t, serviceV3.GetEndpointResponse(), "Hello World v3", "should have service v3 with endpoint")
 			// routers and their endpoints
 			routerBar := testutil.GetRoute(t, "route-bar", "/bv0")
 			assert.Equal(t, "/bv0", routerBar.Router.Spec.Routes[0].Matches[0].Path.Exact, "should have correct route set")

--- a/tests/testutil/service.go
+++ b/tests/testutil/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -133,20 +134,6 @@ func (ts *TestService) Stage(source, version string) TestService {
 	return stagedService
 }
 
-// GetEndpoint performs an http.get against the service endpoint and returns response if
-// status code is 200, otherwise it errors out
-func (ts *TestService) GetEndpoint() string {
-	endpoint, err := ts.waitForEndpointDNS()
-	if err != nil {
-		ts.T.Fatal(err.Error())
-	}
-	response, err := WaitForURLResponse(endpoint)
-	if err != nil {
-		ts.T.Fatal(err.Error())
-	}
-	return response
-}
-
 // Export calls "rio export {serviceName}" and returns that in a new TestService object
 func (ts *TestService) Export() TestService {
 	args := []string{"export", "--type", "service", "--format", "json", ts.Name}
@@ -170,6 +157,24 @@ func (ts *TestService) ExportRaw() TestService {
 //////////
 // Getters
 //////////
+
+// GetEndpointResponse performs an http.get against the service endpoint and returns response if
+// status code is 200, otherwise it errors out
+func (ts *TestService) GetEndpointResponse() string {
+	response, err := WaitForURLResponse(ts.GetEndpointURL())
+	if err != nil {
+		ts.T.Fatal(err.Error())
+	}
+	return response
+}
+
+func (ts *TestService) GetAppEndpointResponse() string {
+	response, err := WaitForURLResponse(ts.GetAppEndpointURL())
+	if err != nil {
+		ts.T.Fatal(err.Error())
+	}
+	return response
+}
 
 // Returns count of ready and available pods
 func (ts *TestService) GetAvailableReplicas() int {
@@ -219,6 +224,68 @@ func (ts *TestService) GetRunningPods() string {
 		ts.T.Fatalf("Failed to get running pods:  %v", err.Error())
 	}
 	return out
+}
+
+// GetEndpointURL returns the URL for this service's app
+func (ts *TestService) GetEndpointURL() string {
+	url, err := ts.waitForEndpointDNS()
+	if err != nil {
+		ts.T.Fatalf("Failed to get the endpoint url:  %v", err.Error())
+		return ""
+	}
+	return url
+}
+
+// GetAppEndpointURL retrieves the service's app endpoint URL and returns it as string
+func (ts *TestService) GetAppEndpointURL() string {
+	url, err := ts.waitForAppEndpointDNS()
+	if err != nil {
+		ts.T.Fatalf("Failed to get the endpoint url:  %v", err.Error())
+		return ""
+	}
+	return url
+}
+
+// GetKubeEndpointURL returns the app revision endpoint URL
+// and returns it as string
+func (ts *TestService) GetKubeEndpointURL() string {
+	_, err := ts.waitForEndpointDNS()
+	if err != nil {
+		ts.T.Fatalf("Failed waiting for DNS:  %v", err.Error())
+		return ""
+	}
+	args := []string{"get", "service.rio.cattle.io",
+		"-n", testingNamespace,
+		ts.Service.Name,
+		"-o", `jsonpath="{.status.endpoints[0]}"`}
+	url, err := KubectlCmd(args)
+	if err != nil {
+		ts.T.Fatalf("Failed to get endpoint url:  %v", err.Error())
+		return ""
+	}
+	return strings.Replace(url, "\"", "", -1) // remove double quotes from output
+}
+
+// GetKubeAppEndpointURL returns the endpoint URL of the service's app
+// by using kubectl and returns it as string
+func (ts *TestService) GetKubeAppEndpointURL() string {
+	_, err := ts.waitForAppEndpointDNS()
+	if err != nil {
+		ts.T.Fatalf("Failed waiting for DNS:  %v", err.Error())
+		return ""
+	}
+	appName := strings.Split(ts.AppName, "/")[1]
+	args := []string{"get", "apps",
+		"-n", testingNamespace,
+		appName,
+		"-o", `jsonpath="{.status.endpoints[0]}"`}
+	url, err := KubectlCmd(args)
+	if err != nil {
+		ts.T.Fatalf("Failed to get app endpoint url:  %v", err.Error())
+		return ""
+	}
+
+	return strings.Replace(url, "\"", "", -1) // remove double quotes from output
 }
 
 //////////////////
@@ -371,4 +438,24 @@ func (ts *TestService) waitForEndpointDNS() (string, error) {
 		return "", errors.New("service endpoint never created")
 	}
 	return ts.Service.Status.Endpoints[0], nil
+}
+
+func (ts *TestService) waitForAppEndpointDNS() (string, error) {
+	if len(ts.App.Status.Endpoints) > 0 {
+		return ts.App.Status.Endpoints[0], nil
+	}
+	f := wait.ConditionFunc(func() (bool, error) {
+		err := ts.reloadApp()
+		if err == nil {
+			if len(ts.App.Status.Endpoints) > 0 {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	err := wait.Poll(2*time.Second, 60*time.Second, f)
+	if err != nil {
+		return "", errors.New("app endpoint never created")
+	}
+	return ts.App.Status.Endpoints[0], nil
 }

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -101,4 +102,12 @@ func RandomString(length int) string {
 
 func GenerateName() string {
 	return strings.Replace(namesgenerator.GetRandomName(2), "_", "-", -1)
+}
+
+func GetHostname(URL string) string {
+	u, err := url.Parse(URL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }


### PR DESCRIPTION
This validates the endpoint URLs generated by rio for the revisions and not versioned are present.

https://github.com/rancher/rio/issues/559