### PR TITLE
Add P1 tests to integration and validation

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,6 +14,7 @@ RUN mkdir -p /go/src/golang.org/x && \
     cd /go/src/golang.org/x && git clone https://github.com/golang/tools && \
     git -C /go/src/golang.org/x/tools checkout -b current aa82965741a9fecd12b026fbb3d3c6ed3231b8f8 && \
     go install golang.org/x/tools/cmd/goimports
+RUN go get -u github.com/rakyll/hey
 RUN rm -rf /go/src /go/pkg
 RUN if [ "${ARCH}" == "amd64" ]; then \
         curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0; \

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,9 +25,21 @@ go test -v -race ./tests/integration/... -integration-tests
 
 Every spec should be in the `when x, it should y` format.
 
-Dev Notes
 
-* Logic lives in the testutil dir, test specs live in the integration folder
+### Validation tests
+
+Validation tests live inside the /tests/validation dir. They require a working cluster with KUBECONFIG env var set, and rio already installed.
+In the future, rio will be installed as part of the tests.
+
+```
+go test -v -race ./tests/validation/... -validation-tests
+```
+
+These tests should not be used to block merging PRs. They are meant to run in other CI and run less regularly. They are also the place where more obscure tests that are useful for regression can be written.
+
+### Integration/Validation Dev Notes
+
+* Logic lives in the testutil dir, test specs live in the integration or validation folder
 * We are purposefully failing tests in the util code rather than returning errors in order to keep specs clean
     * Only fail tests in public methods. Public methods should not call each other.
 * To add a new suite, create a file and add it in the TestSuite list
@@ -43,7 +55,6 @@ Goland is useful for debugging, setup with:
 * package: `github.com/rancher/rio/tests/integration`
 * environment: set your `KUBECONFIG`
 * program arguments: `--integration-tests`
-
 
 ### Full suite
 

--- a/tests/integration/domain_test.go
+++ b/tests/integration/domain_test.go
@@ -15,7 +15,7 @@ func domainTests(t *testing.T, when spec.G, it spec.S) {
 	var domain testutil.TestDomain
 
 	it.Before(func() {
-		service.Create(t, "nginx")
+		service.Create(t)
 	})
 
 	it.After(func() {

--- a/tests/integration/endpoint_test.go
+++ b/tests/integration/endpoint_test.go
@@ -14,16 +14,17 @@ func endpointTests(t *testing.T, when spec.G, it spec.S) {
 	var service testutil.TestService
 	var stagedService testutil.TestService
 
-	it.Before(func() {
-		service.Create(t, "ibuildthecloud/demo:v1")
-	})
-	it.After(func() {
-		service.Remove()
-		stagedService.Remove()
-	})
-
 	when("a service is running and another is staged", func() {
-		it("should have endpoints that are available on both", func() {
+
+		it.Before(func() {
+			service.Create(t, "ibuildthecloud/demo:v1")
+		})
+		it.After(func() {
+			service.Remove()
+			stagedService.Remove()
+		})
+
+		it("should have endpoints that are available on both with one app endpoint", func() {
 			stagedService = service.Stage("ibuildthecloud/demo:v3", "v3")
 
 			// Check the hostnames returned by Rio and Kubectl are equal
@@ -38,15 +39,42 @@ func endpointTests(t *testing.T, when spec.G, it spec.S) {
 
 			assert.Equal(t, "Hello World", service.GetEndpointResponse())
 			assert.Equal(t, "Hello World v3", stagedService.GetEndpointResponse())
-		})
-		it("should have the service app endpoint properly created", func() {
 
-			// Check the hostnames returned by Rio and Kubectl are equal
 			assert.Equal(t,
 				testutil.GetHostname(service.GetKubeAppEndpointURL()),
 				testutil.GetHostname(service.GetAppEndpointURL()),
 			)
+			assert.Equal(t,
+				testutil.GetHostname(service.GetAppEndpointURL()),
+				testutil.GetHostname(stagedService.GetAppEndpointURL()),
+			)
 			assert.Equal(t, "Hello World", service.GetAppEndpointResponse())
+		})
+	}, spec.Parallel())
+
+	when("a staged service is promoted", func() {
+		it.Before(func() {
+			service.Create(t, "ibuildthecloud/demo:v1")
+			stagedService = service.Stage("ibuildthecloud/demo:v3", "v3")
+			stagedService.Promote()
+		})
+		it.After(func() {
+			service.Remove()
+			stagedService.Remove()
+		})
+
+		it("should retain all revision endpoints with an app endpoint pointing to the new revision", func() {
+			assert.Equal(t, "Hello World", service.GetEndpointResponse())
+			assert.Equal(t, "Hello World v3", stagedService.GetEndpointResponse())
+			assert.Equal(t, 0, service.GetKubeCurrentWeight())
+			assert.Equal(t, 100, stagedService.GetKubeCurrentWeight())
+			assert.Equal(t, "Hello World v3", service.GetAppEndpointResponse())
+		})
+		it("should allow rolling back to the previous revision", func() {
+			service.Promote()
+			assert.Equal(t, 100, service.GetKubeCurrentWeight())
+			assert.Equal(t, 0, stagedService.GetKubeCurrentWeight())
+			assert.Equal(t, "Hello World", service.GetEndpointResponse())
 		})
 	}, spec.Parallel())
 }

--- a/tests/integration/riofile_test.go
+++ b/tests/integration/riofile_test.go
@@ -36,6 +36,12 @@ func riofileTests(t *testing.T, when spec.G, it spec.S) {
 			serviceV3 := testutil.GetService(t, "export-test-image", "v3")
 			assert.Equal(t, serviceV0.GetEndpointResponse(), "Hello World", "should have service v0 with endpoint")
 			assert.Equal(t, serviceV3.GetEndpointResponse(), "Hello World v3", "should have service v3 with endpoint")
+			runningPods := serviceV0.GetRunningPods()
+			assert.Len(t, runningPods, 2, "There should be 2 pods associated with the service's app since there are two revisions at scale of 1")
+			for _, pod := range runningPods {
+				assert.Contains(t, pod, "export-test-image")
+				assert.Contains(t, pod, "2/2")
+			}
 			// routers and their endpoints
 			routerBar := testutil.GetRoute(t, "route-bar", "/bv0")
 			assert.Equal(t, "/bv0", routerBar.Router.Spec.Routes[0].Matches[0].Path.Exact, "should have correct route set")
@@ -43,6 +49,8 @@ func riofileTests(t *testing.T, when spec.G, it spec.S) {
 			routerFooV3 := testutil.GetRoute(t, "route-foo", "/v3")
 			assert.Equal(t, "Hello World", routerFooV0.GetEndpointResponse(), "should have working route paths for v1")
 			assert.Equal(t, "Hello World v3", routerFooV3.GetEndpointResponse(), "should have working route paths for v3")
+			assert.Equal(t, "Hello World", routerFooV0.GetKubeEndpointResponse())
+			assert.Equal(t, "Hello World v3", routerFooV3.GetKubeEndpointResponse())
 		})
 	}, spec.Parallel())
 }

--- a/tests/integration/run_test.go
+++ b/tests/integration/run_test.go
@@ -13,22 +13,63 @@ func runTests(t *testing.T, when spec.G, it spec.S) {
 
 	var service testutil.TestService
 
-	it.Before(func() {
-		service.Create(t, "nginx")
-	})
-
 	it.After(func() {
 		service.Remove()
 	})
 
 	when("rio run is called", func() {
-		it("should create a service with default specifications", func() {
-			runningPods := service.GetRunningPods()
+
+		it.Before(func() {
+			service.Create(t)
+		})
+
+		it("should create a service with default specifications that can scale up", func() {
 			assert.Equal(t, 1, service.GetAvailableReplicas(), "should have one available replica")
 			assert.Equal(t, 100, service.GetCurrentWeight())
 			assert.Equal(t, "nginx", service.GetImage())
-			assert.Contains(t, runningPods, service.App.Name)
-			assert.Contains(t, runningPods, "2/2")
+			assert.Contains(t, service.Logs(), "linkerd-init")
+			assert.Contains(t, service.Exec("env"), "KUBERNETES_SERVICE_PORT")
+			runningPods := service.GetRunningPods()
+			for _, pod := range runningPods {
+				assert.Contains(t, pod, service.App.Name)
+				assert.Contains(t, pod, "2/2")
+			}
+
+			service.GenerateLoad()
+			assert.Greater(t, service.GetAvailableReplicas(), 1, "should have more than 1 available replica")
+			runningPods = service.GetRunningPods()
+			assert.Greater(t, len(runningPods), 1)
 		})
-	})
+	}, spec.Parallel())
+
+	when("run a service with a fixed scale", func() {
+
+		it.Before(func() {
+			service.Create(t, "--scale", "3", "https://github.com/rancher/rio-demo")
+		})
+
+		it("should have the specified scale, no autoscaling, and be able to have its scale manually adjusted", func() {
+			assert.Equal(t, 3, service.GetAvailableReplicas(), "should have three available replicas")
+			assert.Equal(t, "Hi there, I'm running in Rio", service.GetAppEndpointResponse())
+
+			service.GenerateLoad()
+			assert.Equal(t, 3, service.GetAvailableReplicas(), "should have three available replicas")
+			runningPods := service.GetRunningPods()
+			assert.Len(t, runningPods, 3)
+			for _, pod := range runningPods {
+				assert.Contains(t, pod, service.App.Name)
+				assert.Contains(t, pod, "2/2")
+			}
+
+			service.Scale(1)
+			assert.Equal(t, 1, service.GetAvailableReplicas(), "should have one available replica")
+			assert.Equal(t, 1, service.GetScale())
+			runningPods = service.GetRunningPods()
+			assert.Len(t, runningPods, 1)
+			for _, pod := range runningPods {
+				assert.Contains(t, pod, service.App.Name)
+				assert.Contains(t, pod, "2/2")
+			}
+		})
+	}, spec.Parallel())
 }

--- a/tests/integration/scale_test.go
+++ b/tests/integration/scale_test.go
@@ -22,10 +22,11 @@ func scaleTests(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("scale is called on a service", func() {
-		it("should scale up", func() {
+		it("should scale up to 3", func() {
 			assert.Equal(t, 1, service.GetAvailableReplicas())
-			service.Scale(2)
-			assert.Equal(t, 2, service.GetAvailableReplicas())
+			service.Scale(3)
+			assert.Equal(t, 3, service.GetScale())
+			assert.Equal(t, 3, service.GetAvailableReplicas())
 			assert.Equal(t, service.GetKubeAvailableReplicas(), service.GetAvailableReplicas())
 			assert.True(t, service.PodsResponsesMatchAvailableReplicas("/name.html", service.GetAvailableReplicas()))
 		})
@@ -36,27 +37,11 @@ func scaleTests(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, 0, service.GetAvailableReplicas())
 			assert.Equal(t, 0, service.GetScale())
 		})
-		it("should scale to 3", func() {
+		it("should scale to 11", func() {
 			assert.Equal(t, 1, service.GetAvailableReplicas())
-			service.Scale(3)
-			assert.Equal(t, 3, service.GetAvailableReplicas())
-			assert.Equal(t, 3, service.GetScale())
-			assert.Equal(t, service.GetKubeAvailableReplicas(), service.GetAvailableReplicas())
-			assert.True(t, service.PodsResponsesMatchAvailableReplicas("/name.html", service.GetAvailableReplicas()))
-		})
-		it("should scale to 5", func() {
-			assert.Equal(t, 1, service.GetAvailableReplicas())
-			service.Scale(5)
-			assert.Equal(t, 5, service.GetAvailableReplicas())
-			assert.Equal(t, 5, service.GetScale())
-			assert.Equal(t, service.GetKubeAvailableReplicas(), service.GetAvailableReplicas())
-			assert.True(t, service.PodsResponsesMatchAvailableReplicas("/name.html", service.GetAvailableReplicas()))
-		})
-		it("should scale to 10", func() {
-			assert.Equal(t, 1, service.GetAvailableReplicas())
-			service.Scale(10)
-			assert.Equal(t, 10, service.GetAvailableReplicas())
-			assert.Equal(t, 10, service.GetScale())
+			service.Scale(11)
+			assert.Equal(t, 11, service.GetAvailableReplicas())
+			assert.Equal(t, 11, service.GetScale())
 			assert.Equal(t, service.GetKubeAvailableReplicas(), service.GetAvailableReplicas())
 			assert.True(t, service.PodsResponsesMatchAvailableReplicas("/name.html", service.GetAvailableReplicas()))
 		})

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testutil.PreCheck()
+	testutil.IntegrationPreCheck()
 	os.Exit(m.Run())
 }
 
 func TestSuite(t *testing.T) {
-	suite := spec.New("rio suite", spec.Report(report.Terminal{}))
+	suite := spec.New("integration suite", spec.Report(report.Terminal{}))
 	specs := map[string]func(t *testing.T, when spec.G, it spec.S){
 		"run":             runTests,
 		"scale":           scaleTests,

--- a/tests/integration/weight_test.go
+++ b/tests/integration/weight_test.go
@@ -31,12 +31,15 @@ func weightTests(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, 100, service.GetKubeCurrentWeight())
 			assert.Equal(t, 0, stagedService.GetKubeCurrentWeight())
 		})
-		it("should be able to move 5% of weight to new revision", func() {
-			stagedService.Weight(5)
-			assert.Equal(t, 95, service.GetCurrentWeight())
-			assert.Equal(t, 5, stagedService.GetCurrentWeight())
-			assert.Equal(t, 95, service.GetKubeCurrentWeight())
-			assert.Equal(t, 5, stagedService.GetKubeCurrentWeight())
+		it("should be able to split weights between revisions", func() {
+			stagedService.Weight(40, false, 5, 5)
+			assert.Equal(t, 60, service.GetCurrentWeight())
+			assert.Equal(t, 40, stagedService.GetCurrentWeight())
+			assert.Equal(t, 60, service.GetKubeCurrentWeight())
+			assert.Equal(t, 40, stagedService.GetKubeCurrentWeight())
+			responses := service.GetResponseCounts([]string{"Hello World", "Hello World v3"}, 12)
+			assert.Greater(t, responses["Hello World"], 2, "The application did not return enough responses from the service. which has slightly more weight than the staged service.")
+			assert.GreaterOrEqual(t, responses["Hello World v3"], 1, "The application did not return enough responses from the staged service. which has slightly less weight than the service.")
 		})
 	}, spec.Parallel())
 }

--- a/tests/validation/autoscale_test.go
+++ b/tests/validation/autoscale_test.go
@@ -1,0 +1,46 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher/rio/tests/testutil"
+)
+
+func autoscaleTests(t *testing.T, when spec.G, it spec.S) {
+
+	var service testutil.TestService
+
+	when("run a service with minscale of 0", func() {
+		it.Before(func() {
+			service.Create(t, "--scale", "0-4", "ibuildthecloud/demo:v1")
+		})
+		it.After(func() {
+			service.Remove()
+		})
+
+		it("should autoscale down to 0", func() {
+			// Precondition
+			assert.Equal(t, 1, service.GetAvailableReplicas(), "should have one initial replica. Failed Precondition")
+			assert.Equal(t, "Hello World", service.GetAppEndpointResponse())
+
+			// When no requests happen for a while, it should scale to 0
+			service.WaitForScaleDown()
+			assert.Equal(t, 0, service.GetAvailableReplicas(), "should have 0 available replicas.")
+			runningPods := service.GetRunningPods()
+			assert.Len(t, runningPods, 0)
+
+			// Send a request and validate it still executes properly and makes one replica and pod available
+			assert.Equal(t, "Hello World", service.GetAppEndpointResponse())
+			assert.Equal(t, 1, service.GetAvailableReplicas(), "should have 1 available replica after the endpoint is called once.")
+			runningPods = service.GetRunningPods()
+			assert.Len(t, runningPods, 1)
+			for _, pod := range runningPods {
+				assert.Contains(t, pod, service.App.Name)
+				assert.Contains(t, pod, "2/2")
+			}
+		})
+	}, spec.Parallel())
+}

--- a/tests/validation/suite_test.go
+++ b/tests/validation/suite_test.go
@@ -1,0 +1,28 @@
+package validation
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/rancher/rio/tests/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testutil.ValidationPreCheck()
+	os.Exit(m.Run())
+}
+
+func TestSuite(t *testing.T) {
+	suite := spec.New("validation suite", spec.Report(report.Terminal{}))
+	specs := map[string]func(t *testing.T, when spec.G, it spec.S){
+		"autoscale": autoscaleTests,
+		"weight":    weightTests,
+	}
+	for desc, fnc := range specs {
+		suite(desc, fnc)
+	}
+	suite.Run(t)
+}

--- a/tests/validation/weight_test.go
+++ b/tests/validation/weight_test.go
@@ -1,0 +1,42 @@
+package validation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher/rio/tests/testutil"
+)
+
+func weightTests(t *testing.T, when spec.G, it spec.S) {
+
+	var service testutil.TestService
+	var stagedService testutil.TestService
+
+	it.Before(func() {
+		service.Create(t, "ibuildthecloud/demo:v1")
+		stagedService = service.Stage("ibuildthecloud/demo:v3", "v3")
+	})
+
+	it.After(func() {
+		service.Remove()
+		stagedService.Remove()
+	})
+
+	when("a staged service incrementally rolls out weight", func() {
+		it("should slowly increase weight on the staged service and decrease current service weight", func() {
+			// This test is known to fail until https://github.com/rancher/rio/issues/577 is resolved.
+			// The time from rollout to obtaining the current weight, without Sleep, is 2 seconds.
+			// Sleeping 8 seconds here with a rollout-interval of 4 seconds to guarantee 2 rollout ticks, plus the initial tick, with 2 seconds to spare.
+			stagedService.Weight(80, true, 10, 4)
+			time.Sleep(8 * time.Second)
+
+			stagedWeightAfter10Seconds := stagedService.GetCurrentWeight()
+			serviceWeightAfter10Seconds := service.GetCurrentWeight()
+			assert.Equal(t, 30, stagedWeightAfter10Seconds)
+			assert.Equal(t, 70, serviceWeightAfter10Seconds)
+		})
+	}, spec.Parallel())
+}


### PR DESCRIPTION
Issue: #570 

This covers the first scenario from the P1 Rio Run Test Cases.
Some changes had to be made to the test framework to accommodate this. The three I'd like to highlight are:
- Installing the "hey" tool into CI to generate load on the endpoitns
- Removing the port from `service.Create()` and adding optional arguments to it. The port should be used as an argument in many cases, but not all. There are also additional run options that are important to test, so having the optional arguments will give us this ability.
-  Added this check in `waitForReadyService()`: `ts.Service.Status.DeploymentStatus.AvailableReplicas == ts.Service.Status.DeploymentStatus.Replicas`. This one I'm not convinced about, but want to get others' feedback. I think it might be better to have a `waitForReadyReplicas()` function that we call in `GetAvailableReplicas()` that has this logic in it. What do we all think?

