### PR TITLE
Reordering the validations in CI

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -6,7 +6,7 @@ cd $(dirname $0)
 export CROSS=true
 
 ./build
-./test
 ./validate
 ./validate-ci
+./test
 ./package


### PR DESCRIPTION
Linter and code formatting errors should happen earlier before tests are executed.