### PR TITLE
Adding kube validations for externalservices

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,7 @@ FROM golang:1.12.6-alpine3.9
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 ENV K3S_VERSION v0.9.1
-ENV KUBECTL_VERSION v1.15.0
+ENV KUBECTL_VERSION v1.15.5
 
 RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
 RUN go get -d golang.org/x/lint/golint && \

--- a/tests/integration/externalservice_test.go
+++ b/tests/integration/externalservice_test.go
@@ -21,12 +21,14 @@ func externalServiceTests(t *testing.T, when spec.G, it spec.S) {
 		it("should have its ip address field populated", func() {
 			externalService.Create(t, "1.2.3.4")
 			assert.Equal(t, "1.2.3.4", externalService.GetFirstIPAddress())
+			assert.Equal(t, externalService.GetFirstIPAddress(), externalService.GetKubeFirstIPAddress())
 		})
 	})
 	when("a config is created with a FQDN", func() {
 		it("should have its FQDN field populated", func() {
 			externalService.Create(t, "test.example.com")
 			assert.Equal(t, "test.example.com", externalService.GetFQDN())
+			assert.Equal(t, externalService.GetFQDN(), externalService.GetKubeFQDN())
 		})
 	})
 }

--- a/tests/integration/riofile_test.go
+++ b/tests/integration/riofile_test.go
@@ -30,8 +30,10 @@ func riofileTests(t *testing.T, when spec.G, it spec.S) {
 			// external services
 			externalFoo := testutil.GetExternalService(t, "es-foo")
 			assert.Equal(t, "www.example.com", externalFoo.GetFQDN(), "should have external service with fqdn")
+			assert.Equal(t, externalFoo.GetKubeFQDN(), externalFoo.GetFQDN(), "should have external service with fqdn from k8s")
 			externalBar := testutil.GetExternalService(t, "es-bar")
 			assert.Equal(t, "1.1.1.1", externalBar.GetFirstIPAddress(), "should have external service with ip")
+			assert.Equal(t, externalBar.GetFirstIPAddress(), externalBar.GetKubeFirstIPAddress(), "should have external service with ip from k8s")
 			// services and their endpoints
 			serviceV0 := testutil.GetService(t, "export-test-image", "v0")
 			serviceV3 := testutil.GetService(t, "export-test-image-v3", "v3")


### PR DESCRIPTION
This is part of #559 Add kubectl validations to the test framework