### PR TITLE
allow version to be specd in service name on run

### DIFF
--- a/cli/cmd/create/create.go
+++ b/cli/cmd/create/create.go
@@ -96,6 +96,7 @@ func (c *Create) RunCallback(ctx *clicontext.CLIContext, cb func(service *riov1.
 	}
 
 	service.Namespace, service.Name = stack.NamespaceAndName(ctx, service.Name)
+	service.Name, service.Spec.Version = kv.Split(service.Name, ":")
 
 	service = cb(service)
 	return service, ctx.Create(service)


### PR DESCRIPTION
Allows a user to run: `rio run -n svc:v1 nginx` and have version correctly set