### PR TITLE
Moving Scale to 11 test to the validation test suite

### DIFF
--- a/tests/validation/scale_test.go
+++ b/tests/validation/scale_test.go
@@ -1,0 +1,34 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher/rio/tests/testutil"
+)
+
+func scaleTests(t *testing.T, when spec.G, it spec.S) {
+
+	var service testutil.TestService
+
+	it.Before(func() {
+		service.Create(t, "sangeetha/mytestcontainer")
+	})
+
+	it.After(func() {
+		service.Remove()
+	})
+
+	when("scale is called on a service", func() {
+		it("should scale to 11", func() {
+			assert.Equal(t, 1, service.GetAvailableReplicas())
+			service.Scale(11)
+			assert.Equal(t, 11, service.GetAvailableReplicas())
+			assert.Equal(t, 11, service.GetScale())
+			assert.Equal(t, service.GetKubeAvailableReplicas(), service.GetAvailableReplicas())
+			assert.True(t, service.PodsResponsesMatchAvailableReplicas("/name.html", service.GetAvailableReplicas()))
+		})
+	}, spec.Parallel())
+}

--- a/tests/validation/suite_test.go
+++ b/tests/validation/suite_test.go
@@ -18,6 +18,7 @@ func TestMain(m *testing.M) {
 func TestSuite(t *testing.T) {
 	suite := spec.New("validation suite", spec.Report(report.Terminal{}))
 	specs := map[string]func(t *testing.T, when spec.G, it spec.S){
+		"scale":     scaleTests,
 		"autoscale": autoscaleTests,
 		"weight":    weightTests,
 	}


### PR DESCRIPTION
```bash
=== RUN   TestSuite
Suite: validation suite
Total: 3 | Focused: 1 | Pending: 0
Focus is active.
=== RUN   TestSuite/validation_suite
=== RUN   TestSuite/validation_suite/scale/scale_is_called_on_a_service/should_scale_to_11
=== PAUSE TestSuite/validation_suite/scale/scale_is_called_on_a_service/should_scale_to_11
=== RUN   TestSuite/validation_suite/autoscale/run_a_service_with_minscale_of_0/should_autoscale_down_to_0
=== RUN   TestSuite/validation_suite/weight/a_staged_service_incrementally_rolls_out_weight/should_slowly_increase_weight_on_the_staged_service_and_decrease_current_service_weight
=== CONT  TestSuite/validation_suite/scale/scale_is_called_on_a_service/should_scale_to_11

Passed: 1 | Failed: 0 | Skipped: 2

--- PASS: TestSuite (218.10s)
    --- PASS: TestSuite/validation_suite (0.00s)
        --- SKIP: TestSuite/validation_suite/autoscale/run_a_service_with_minscale_of_0/should_autoscale_down_to_0 (0.00s)
        --- SKIP: TestSuite/validation_suite/weight/a_staged_service_incrementally_rolls_out_weight/should_slowly_increase_weight_on_the_staged_service_and_decrease_current_service_weight (0.00s)
        --- PASS: TestSuite/validation_suite/scale/scale_is_called_on_a_service/should_scale_to_11 (218.10s)
PASS
ok  	github.com/rancher/rio/tests/validation	218.457s
```