### PR TITLE
Riofiles will modify resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/rancher/mapper v0.0.0-20190814232720-058a8b7feb99
 	github.com/rancher/norman v0.0.0-20191030191625-ebecbda5fbe3
 	github.com/rancher/rdns-server v0.5.7-0.20190927164127-7128efe7d065
-	github.com/rancher/wrangler v0.2.1-0.20191025041946-1fd360590735
+	github.com/rancher/wrangler v0.2.1-0.20191101235852-ff10906d8415
 	github.com/rancher/wrangler-api v0.2.1-0.20191025043713-b1ca9c21825a
 	github.com/sclevine/spec v1.3.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -868,8 +868,9 @@ github.com/rancher/wrangler v0.0.0-20190426050201-5946f0eaed19/go.mod h1:snD4YYj
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.1.7-0.20190824203417-e7b6ecb74e90/go.mod h1:TLc4vXF21FWz2MYNHny5zDwFwBqvgBViU5n9CHrJRQ0=
 github.com/rancher/wrangler v0.2.1-0.20191015042916-f2a6ecca4f20/go.mod h1:w9jivI6vlBZmqzizNQM0Li/ZwoNTBeDpIv+NtBoFiMI=
-github.com/rancher/wrangler v0.2.1-0.20191025041946-1fd360590735 h1:k4T5zGP/JYwulh0IFBJ9Q7sDr2N8NOcoDIEXcaXatZw=
 github.com/rancher/wrangler v0.2.1-0.20191025041946-1fd360590735/go.mod h1:zmXTOSzU0vhumCyl0+Acq2FEP5WJOJRqnCQDegknyWA=
+github.com/rancher/wrangler v0.2.1-0.20191101235852-ff10906d8415 h1:NSFtbSSXkvum6rYN7J6zGC5aNbKrogRWWhySIKIQdxg=
+github.com/rancher/wrangler v0.2.1-0.20191101235852-ff10906d8415/go.mod h1:zmXTOSzU0vhumCyl0+Acq2FEP5WJOJRqnCQDegknyWA=
 github.com/rancher/wrangler-api v0.1.4/go.mod h1:Mc8bNN5rNxpQ7am2orUbonahw4xJ6ztF+fUTSku8KnE=
 github.com/rancher/wrangler-api v0.2.1-0.20191025043713-b1ca9c21825a h1:dH3D71jzKuYRY7qLe9AKuwz8DKO6G9PCfkeafETMmZo=
 github.com/rancher/wrangler-api v0.2.1-0.20191025043713-b1ca9c21825a/go.mod h1:U4nfgObQ7EERMwljGhCfQIbh2ql/t8suINX8/VfWiko=

--- a/pkg/riofile/riofile.go
+++ b/pkg/riofile/riofile.go
@@ -127,6 +127,7 @@ func isK8SYaml(contents []byte) (bool, []runtime.Object, error) {
 	return false, nil, nil
 }
 
+// Parse converts a textfile into a Riofile struct
 func Parse(contents []byte, answers template.AnswerCallback) (*Riofile, error) {
 	k8s, objs, err := isK8SYaml(contents)
 	if err != nil {

--- a/scripts/build
+++ b/scripts/build
@@ -18,4 +18,4 @@ if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/rio-darwin ./cli
     GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/rio-windows ./cli
 fi
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/rio-controller
+GOOS=linux CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/rio-controller

--- a/tests/integration/fixtures/riofile-with-K8s-manifests-after.yaml
+++ b/tests/integration/fixtures/riofile-with-K8s-manifests-after.yaml
@@ -1,0 +1,19 @@
+configs:
+  conf:
+    index.html: |-
+      <!DOCTYPE html>
+      <html>
+      <body>
+
+      <h1>Hello Rio</h1>
+
+      </body>
+      </html>
+services:
+  nginx:
+    image: nginx
+    version: v0
+    ports:
+      - 80/http
+    configs:
+      - conf/index.html:/usr/share/nginx/html/index.html

--- a/tests/integration/fixtures/riofile-with-K8s-manifests-before.yaml
+++ b/tests/integration/fixtures/riofile-with-K8s-manifests-before.yaml
@@ -1,0 +1,169 @@
+configs:
+  conf:
+    index.html: |-
+      <!DOCTYPE html>
+      <html>
+      <body>
+
+      <h1>Hello World</h1>
+
+      </body>
+      </html>
+services:
+  nginx:
+    image: nginx
+    version: v0
+    ports:
+      - 80/http
+    configs:
+      - conf/index.html:/usr/share/nginx/html/index.html
+
+kubernetes:
+  manifest: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: redis-master
+      labels:
+        app: redis
+        tier: backend
+        role: master
+    spec:
+      ports:
+      - port: 6379
+        targetPort: 6379
+      selector:
+        app: redis
+        tier: backend
+        role: master
+    ---
+    apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+    kind: Deployment
+    metadata:
+      name: redis-master
+    spec:
+      selector:
+        matchLabels:
+          app: redis
+          role: master
+          tier: backend
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            app: redis
+            role: master
+            tier: backend
+        spec:
+          containers:
+          - name: master
+            image: k8s.gcr.io/redis:e2e  # or just image: redis
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            ports:
+            - containerPort: 6379
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: redis-slave
+      labels:
+        app: redis
+        tier: backend
+        role: slave
+    spec:
+      ports:
+      - port: 6379
+      selector:
+        app: redis
+        tier: backend
+        role: slave
+    ---
+    apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+    kind: Deployment
+    metadata:
+      name: redis-slave
+    spec:
+      selector:
+        matchLabels:
+          app: redis
+          role: slave
+          tier: backend
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            app: redis
+            role: slave
+            tier: backend
+        spec:
+          containers:
+          - name: slave
+            image: gcr.io/google_samples/gb-redisslave:v1
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            env:
+            - name: GET_HOSTS_FROM
+              value: dns
+              # If your cluster config does not include a dns service, then to
+              # instead access an environment variable to find the master
+              # service's host, comment out the 'value: dns' line above, and
+              # uncomment the line below:
+              # value: env
+            ports:
+            - containerPort: 6379
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: frontend
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      # if your cluster supports it, uncomment the following to automatically create
+      # an external load-balanced IP for the frontend service.
+      # type: LoadBalancer
+      ports:
+      - port: 80
+      selector:
+        app: guestbook
+        tier: frontend
+    ---
+    apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+    kind: Deployment
+    metadata:
+      name: frontend
+    spec:
+      selector:
+        matchLabels:
+          app: guestbook
+          tier: frontend
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            app: guestbook
+            tier: frontend
+        spec:
+          containers:
+          - name: php-redis
+            image: gcr.io/google-samples/gb-frontend:v4
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            env:
+            - name: GET_HOSTS_FROM
+              value: dns
+              # If your cluster config does not include a dns service, then to
+              # instead access environment variables to find service host
+              # info, comment out the 'value: dns' line above, and uncomment the
+              # line below:
+              # value: env
+            ports:
+            - containerPort: 80

--- a/tests/testutil/riofile.go
+++ b/tests/testutil/riofile.go
@@ -19,9 +19,11 @@ type TestRiofile struct {
 }
 
 // Bring up a riofile by fixture file
-func (trf *TestRiofile) Up(t *testing.T, filename string) {
+func (trf *TestRiofile) Up(t *testing.T, filename, stackName string) {
 	trf.T = t
-	stackName := RandomString(5)
+	if stackName == "" {
+		stackName = RandomString(5)
+	}
 	trf.Name = fmt.Sprintf("stack/%s/%s", testingNamespace, stackName)
 	pwd, err := os.Getwd()
 	if err != nil {

--- a/vendor/github.com/rancher/wrangler/pkg/apply/apply.go
+++ b/vendor/github.com/rancher/wrangler/pkg/apply/apply.go
@@ -49,6 +49,7 @@ type Apply interface {
 	WithListerNamespace(ns string) Apply
 	WithRateLimiting(ratelimitingQps float32) Apply
 	WithNoDelete() Apply
+	WithGVK(gvks ...schema.GroupVersionKind) Apply
 	WithSetOwnerReference(controller, block bool) Apply
 }
 
@@ -168,6 +169,10 @@ func (a *apply) WithInjectorName(injs ...string) Apply {
 
 func (a *apply) WithCacheTypes(igs ...InformerGetter) Apply {
 	return a.newDesiredSet().WithCacheTypes(igs...)
+}
+
+func (a *apply) WithGVK(gvks ...schema.GroupVersionKind) Apply {
+	return a.newDesiredSet().WithGVK(gvks...)
 }
 
 func (a *apply) WithPatcher(gvk schema.GroupVersionKind, patcher Patcher) Apply {

--- a/vendor/github.com/rancher/wrangler/pkg/apply/desiredset.go
+++ b/vendor/github.com/rancher/wrangler/pkg/apply/desiredset.go
@@ -56,6 +56,19 @@ func (o desiredSet) ApplyObjects(objs ...runtime.Object) error {
 	return o.Apply(os)
 }
 
+// WithGVK uses a known listing of existing gvks to modify the the prune types to allow for deletion of objects
+func (o desiredSet) WithGVK(gvks ...schema.GroupVersionKind) Apply {
+	pruneTypes := make(map[schema.GroupVersionKind]cache.SharedIndexInformer, len(gvks))
+	for k, v := range o.pruneTypes {
+		pruneTypes[k] = v
+	}
+	for _, gvk := range gvks {
+		pruneTypes[gvk] = nil
+	}
+	o.pruneTypes = pruneTypes
+	return o
+}
+
 func (o desiredSet) WithSetID(id string) Apply {
 	o.setID = id
 	return o
@@ -84,7 +97,7 @@ func (o desiredSet) WithInjectorName(injs ...string) Apply {
 }
 
 func (o desiredSet) WithCacheTypes(igs ...InformerGetter) Apply {
-	pruneTypes := map[schema.GroupVersionKind]cache.SharedIndexInformer{}
+	pruneTypes := make(map[schema.GroupVersionKind]cache.SharedIndexInformer, len(igs))
 	for k, v := range o.pruneTypes {
 		pruneTypes[k] = v
 	}

--- a/vendor/github.com/rancher/wrangler/pkg/gvk/get.go
+++ b/vendor/github.com/rancher/wrangler/pkg/gvk/get.go
@@ -31,7 +31,7 @@ func Set(obj runtime.Object) error {
 	if gvk.Kind != "" {
 		return nil
 	}
-	
+
 	gvks, _, err := schemes.All.ObjectKinds(obj)
 	if err != nil {
 		return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -481,7 +481,7 @@ github.com/rancher/norman/pkg/types/values
 # github.com/rancher/rdns-server v0.5.7-0.20190927164127-7128efe7d065
 github.com/rancher/rdns-server/client
 github.com/rancher/rdns-server/model
-# github.com/rancher/wrangler v0.2.1-0.20191025041946-1fd360590735
+# github.com/rancher/wrangler v0.2.1-0.20191101235852-ff10906d8415
 github.com/rancher/wrangler/pkg/apply
 github.com/rancher/wrangler/pkg/apply/injectors
 github.com/rancher/wrangler/pkg/cleanup


### PR DESCRIPTION
 Riofiles will modify resources

This changes modifies the apply logic to allow for a set of previously
seen GVKs to be passed into the Apply logic.

This allows for the stack to delete objects that are no longer present
in the Riofile on the next `rio up` run.