### PR TITLE
Create Dockerfile for tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.13-alpine
+
+# Install all needed tools
+RUN apk update && \
+  apk upgrade --update-cache --available && \
+  apk add build-base curl git
+
+# Install the executables for kubectl, rio, and hey
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+  chmod +x ./kubectl && \
+  mv ./kubectl /usr/local/bin && \
+  go get -u github.com/rakyll/hey
+
+# Set working directory to rio application directory and install all go dependencies
+WORKDIR /usr/local/projects/rio
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy source code into working directory and make sure entrypoint is executable
+COPY . .
+RUN chmod +x ./tests/entrypoint.sh
+
+# Set environment variables for tests to run properly and to ensure the correct rio version is being tested
+ENV INSTALL_RIO_VERSION=v0.6.0-alpha.2
+ENV KUBECONFIG /usr/local/projects/rio/.kube/config
+ENV test validation
+
+# Install Rio if needed and run tests
+ENTRYPOINT [ "./tests/entrypoint.sh" ]
+CMD go test -v ./tests/${test}/... -${test}-tests

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+curl -sfL https://get.rio.io | sh - > /dev/null 2>&1
+
+# Install rio if it isn't already installed
+if [ "$(rio info | grep "rio install")" ] ; then rio install ; fi
+
+exec "$@"


### PR DESCRIPTION
Added a docker build for tests to run integration or validation tests so that these can be run easily in any environment. 
Note that this expects a released/pre-release version of rio. 
For local development, you will need to add to the Dockerfile to copy your local rio cli binary.


**Example Local Run**
1. Add a KUBECONFIG file to `/path/to/rio/.kube/config`
2. Make sure you have docker installed, then run the following in a terminal:
```
docker build -f "/path/to/rio/tests/Dockerfile" -t rio-test /path/to/rio
docker run --rm -e test=integration rio-test:latest
docker run --rm -e test=validation rio-test:latest
docker run --rm -e test=integration -e INSTALL_RIO_VERSION=v0.6.0-alpha.x rio-test:latest
```

**Example Jenkins Shell Script:**
```
docker build -f "${WORKSPACE}/tests/Dockerfile" -t rio-test .
docker run --rm -e test=${Type} rio-test:latest ${RunCommand}
```
**Example Jenkins Parameters:**
_File Parameter_: `Location`=`.kube/config`
_Choice Parameter_: `Type`=`integration` and `validation`
_String Parameter_: `Name`=`RunCommand`, and leave `Default Value` blank