### PR TITLE
Stage updates orig svc weights

### DIFF
--- a/cli/cmd/promote/promote.go
+++ b/cli/cmd/promote/promote.go
@@ -30,7 +30,10 @@ func (p *Promote) Run(ctx *clicontext.CLIContext) error {
 	if err != nil {
 		return err
 	}
-	svc := ctx.ParseID(serviceName)
+	versionToPromote := ctx.ParseID(serviceName).Version
+	if versionToPromote == "" {
+		return errors.New("invalid version specified")
+	}
 
 	for _, s := range svcs {
 		err := ctx.UpdateResource(types.Resource{
@@ -49,7 +52,7 @@ func (p *Promote) Run(ctx *clicontext.CLIContext) error {
 				Increment:       p.Increment,
 				IntervalSeconds: p.Interval,
 			}
-			if s.Spec.Version == svc.Version {
+			if s.Spec.Version == versionToPromote {
 				*s.Spec.Weight = 100
 				fmt.Printf("%s promoted\n", s.Name)
 			} else {

--- a/cli/main.go
+++ b/cli/main.go
@@ -178,7 +178,7 @@ func main() {
 			""),
 		builder.Command(&stage.Stage{},
 			"Stage a new revision of a service",
-			appName+" stage [OPTIONS] SERVICE_NAME@NEW_REVISION",
+			appName+" stage [OPTIONS] SERVICE NEW_REVISION",
 			""),
 		builder.Command(&promote.Promote{},
 			"Promote a staged version to latest",

--- a/tests/testutil/service.go
+++ b/tests/testutil/service.go
@@ -165,8 +165,7 @@ func (ts *TestService) Weight(percentage int, args ...string) {
 
 // Call "rio stage --image={source} ns/name:{version}", this will return a new TestService
 func (ts *TestService) Stage(source, version string) TestService {
-	name := fmt.Sprintf("%s@%s", ts.Name, version)
-	_, err := RioCmd([]string{"stage", "--image", source, name})
+	_, err := RioCmd([]string{"stage", "--image", source, ts.Name, version})
 	if err != nil {
 		ts.T.Fatalf("stage command failed:  %v", err.Error())
 	}
@@ -190,7 +189,7 @@ func (ts *TestService) Promote(args ...string) {
 		append(args, ts.Name)...)
 	_, err := RioCmd(args)
 	if err != nil {
-		ts.T.Fatalf("stage command failed:  %v", err.Error())
+		ts.T.Fatalf("promote command failed:  %v", err.Error())
 	}
 	err = ts.waitForWeight(100)
 	if err != nil {


### PR DESCRIPTION
If you stage `svc@v2` and `svc@v1` has 0 spec weight, move v1 to 100 spec weight. 
Also: 

* `-e` is now ENV everywhere
* promote is two part command, does not use `@` anymore