### PR TITLE
Builds CLI as linux by default

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -13,7 +13,7 @@ LINKFLAGS="-X github.com/rancher/rio/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/rancher/rio/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 LINKFLAGS="-X github.com/rancher/rio/pkg/constants.ControllerImage=${REPO}/rio-controller $LINKFLAGS"
 LINKFLAGS="-X github.com/rancher/rio/pkg/constants.ControllerImageTag=${TAG} $LINKFLAGS"
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/rio ./cli
+GOOS=linux CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/rio ./cli
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/rio-darwin ./cli
     GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/rio-windows ./cli


### PR DESCRIPTION
Necessary for new build process, otherwise anyone running a mac builds a darwin CLI which fails inside rio-controller image. 