### PR TITLE
Drop stage cattle labels and limit rollout time

### DIFF
--- a/cli/cmd/promote/promote.go
+++ b/cli/cmd/promote/promote.go
@@ -2,7 +2,10 @@ package promote
 
 import (
 	"errors"
+	"fmt"
 	"time"
+
+	"github.com/rancher/rio/cli/pkg/table"
 
 	"github.com/rancher/rio/cli/cmd/weight"
 	"github.com/rancher/rio/cli/pkg/clicontext"
@@ -32,5 +35,11 @@ func (p *Promote) Run(ctx *clicontext.CLIContext) error {
 	if err != nil {
 		return err
 	}
-	return weight.PromoteService(ctx, resource, rolloutConfig, promoteWeight)
+	err = weight.PromoteService(ctx, resource, rolloutConfig, promoteWeight)
+	if err != nil {
+		return err
+	}
+	id, _ := table.FormatID(resource.Object, resource.Namespace)
+	fmt.Printf("%s promoted\n", id)
+	return nil
 }

--- a/cli/cmd/stage/stage.go
+++ b/cli/cmd/stage/stage.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/aokoli/goutils"
 	"github.com/rancher/rio/cli/cmd/edit/edit"
@@ -116,8 +117,8 @@ func (r *Stage) updatePromotedService(ctx *clicontext.CLIContext, service types.
 		stagedService := riov1.NewService(svc.Namespace, spec.App+"-"+version, riov1.Service{
 			Spec: *spec,
 			ObjectMeta: v1.ObjectMeta{
-				Labels:      svc.Labels,
-				Annotations: svc.Annotations,
+				Labels:      cleanMeta(svc.Labels),
+				Annotations: cleanMeta(svc.Annotations),
 			},
 		})
 		return ctx.Create(stagedService)
@@ -183,4 +184,14 @@ func (r *Stage) mergeEnvVars(currEnvs []riov1.EnvVar) ([]riov1.EnvVar, error) {
 		}
 	}
 	return append(orig, stageEnvs...), nil
+}
+
+func cleanMeta(m map[string]string) map[string]string {
+	r := make(map[string]string)
+	for k, v := range m {
+		if !strings.Contains(k, "rio.cattle.io") {
+			r[k] = v
+		}
+	}
+	return r
 }

--- a/cli/cmd/weight/weight.go
+++ b/cli/cmd/weight/weight.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/rancher/rio/cli/cmd/util"
 	"github.com/rancher/rio/cli/pkg/clicontext"
-	"github.com/rancher/rio/cli/pkg/table"
 	"github.com/rancher/rio/cli/pkg/types"
 	riov1 "github.com/rancher/rio/pkg/apis/rio.cattle.io/v1"
 	"github.com/rancher/rio/pkg/services"
@@ -69,6 +68,9 @@ func (w *Weight) Run(ctx *clicontext.CLIContext) error {
 }
 
 func GenerateWeightAndRolloutConfig(ctx *clicontext.CLIContext, obj types.Resource, targetPercentage int, duration time.Duration, pause bool) (int, *riov1.RolloutConfig, error) {
+	if duration.Hours() > 10 {
+		return 0, nil, errors.New("cannot perform rollout longer than 10 hours") // over 10 hours we go under increment of 1/10k, given 2 second. Also see safety valve below in increment.
+	}
 	svcs, err := util.ListAppServicesFromAppName(ctx, obj.Namespace, obj.App)
 	if err != nil {
 		return 0, nil, err
@@ -100,11 +102,14 @@ func GenerateWeightAndRolloutConfig(ctx *clicontext.CLIContext, obj types.Resour
 
 	// if not immediate rollout figure out increment
 	increment := 0
-	if duration.Seconds() >= 1.0 {
+	if duration.Seconds() >= 2.0 {
 		steps := duration.Seconds() / float64(DefaultInterval)             // First get rough amount of steps we want to take
 		totalNewWeight := totalCurrWeightOtherSvcs + newWeight             // Given the future total weight which includes our newWeight...
 		difference := totalNewWeight - totalCurrWeight                     // Find the difference between future total weight and current total weight
 		increment = int(math.Abs(math.Round(float64(difference) / steps))) // And divide by steps to get rough increment
+		if increment == 0 {                                                // Error out if increment was below 1, and thus rounded to 0
+			return 0, nil, errors.New("Unable to perform rollout, given duration too long")
+		}
 	}
 	rolloutConfig := &riov1.RolloutConfig{
 		Pause:           pause,
@@ -137,8 +142,6 @@ func PromoteService(ctx *clicontext.CLIContext, resource types.Resource, rollout
 				}
 				if version == resource.Version {
 					*s.Spec.Weight = promoteWeight
-					id, _ := table.FormatID(obj, s.Namespace)
-					fmt.Printf("%s promoted\n", id)
 				} else {
 					*s.Spec.Weight = 0
 				}

--- a/cli/cmd/weight/weight.go
+++ b/cli/cmd/weight/weight.go
@@ -89,6 +89,9 @@ func GenerateWeightAndRolloutConfig(ctx *clicontext.CLIContext, obj types.Resour
 			totalCurrWeight += *s.Status.ComputedWeight
 		}
 	}
+	if targetPercentage == int(math.Round(float64(currComputedWeight)/float64(totalCurrWeight)/0.01)) {
+		return 0, nil, errors.New("cannot rollout, already at target percentage")
+	}
 	totalCurrWeightOtherSvcs := totalCurrWeight - currComputedWeight
 
 	newWeight := targetPercentage
@@ -108,7 +111,7 @@ func GenerateWeightAndRolloutConfig(ctx *clicontext.CLIContext, obj types.Resour
 		difference := totalNewWeight - totalCurrWeight                     // Find the difference between future total weight and current total weight
 		increment = int(math.Abs(math.Round(float64(difference) / steps))) // And divide by steps to get rough increment
 		if increment == 0 {                                                // Error out if increment was below 1, and thus rounded to 0
-			return 0, nil, errors.New("Unable to perform rollout, given duration too long")
+			return 0, nil, errors.New("Unable to perform rollout, given duration too long for current weight")
 		}
 	}
 	rolloutConfig := &riov1.RolloutConfig{


### PR DESCRIPTION
Issue: https://github.com/rancher/rio/issues/745

Also adds check for when there are not enough steps to perform rollout on a given distance, for example 50%->51% over 2 hours would fail. 