### PR TITLE
Fixes health-url cli and backend, improves examples

### DIFF
--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -34,7 +34,7 @@ func Config(app *cli.App) cli.Command {
 				app.Name+" config ls",
 				""),
 			builder.Command(&Create{},
-				"Create a config",
+				"Create a config from a file",
 				app.Name+" config create NAME FILE|-",
 				""),
 			NewCatCommand(" config", app),

--- a/cli/cmd/create/create.go
+++ b/cli/cmd/create/create.go
@@ -56,7 +56,7 @@ type Create struct {
 	HealthInterval         string            `desc:"Time between running the check (ms|s|m|h)" default:"0s"`
 	HealthSuccessThreshold int               `desc:"Consecutive successes needed to report healthy"`
 	HealthTimeout          string            `desc:"Maximum time to allow one check to run (ms|s|m|h)" default:"0s"`
-	HealthURL              string            `desc:"URL to hit to check health (example: http://localhost:8080/ping)"`
+	HealthURL              string            `desc:"URL to hit to check health (example: http://:8080/ping)"`
 	Hostname               string            `desc:"Container host name"`
 	I_Interactive          bool              `desc:"Keep STDIN open even if not attached"`
 	ImagePullPolicy        string            `desc:"Behavior determining when to pull the image (never|always|not-present)" default:"not-present"`

--- a/cli/cmd/create/health.go
+++ b/cli/cmd/create/health.go
@@ -3,7 +3,6 @@ package create
 import (
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/mattn/go-shellwords"
@@ -69,19 +68,14 @@ func (c *Create) setHealthCheck(spec *riov1.ServiceSpec) error {
 		if portStr == "" {
 			return fmt.Errorf("missing port in health-url %s", c.HealthURL)
 		}
-		port, err := strconv.Atoi(portStr)
-		if err != nil {
-			return err
-		}
-
 		if u.Scheme == "tcp" {
 			hc.TCPSocket = &v1.TCPSocketAction{
-				Port: intstr.FromInt(port),
+				Port: intstr.FromString(portStr),
 			}
 		} else {
 			hc.HTTPGet = &v1.HTTPGetAction{
-				Port: intstr.FromInt(port),
-				Host: u.Host,
+				Port: intstr.FromString(portStr),
+				Host: u.Hostname(),
 				Path: u.Path,
 			}
 

--- a/tests/integration/run_test.go
+++ b/tests/integration/run_test.go
@@ -67,4 +67,12 @@ func runTests(t *testing.T, when spec.G, it spec.S) {
 			}
 		})
 	}, spec.Parallel())
+
+	when("run a service with liveness check", func() {
+		it("should come become available", func() {
+			service.Create(t, "-p", "80", "--health-url", "http://:80", "--health-initial-delay", "1s", "--health-interval", "1s", "--health-failure-threshold", "1", "--health-timeout", "1s", "ibuildthecloud/demo:v1")
+			assert.Equal(t, 1, service.GetAvailableReplicas(), "should have two available replicas")
+			assert.Equal(t, "Hello World", service.GetAppEndpointResponse())
+		})
+	}, spec.Parallel())
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/rio/issues/750

Examples: 
* `rio run --health-url http://:80 -p 80 nginx`
* `rio run --health-url http://:8080/status --health-initial-delay 10s --health-interval 5s --health-failure-threshold 5 --health-timeout 5s -p 8080 cbron/mybusybox:dev`

