### PR TITLE
Removing back quotes making the command fail when pasting in terminal

### DIFF
--- a/docs/v0.6.0/publicdomain-external-services.md
+++ b/docs/v0.6.0/publicdomain-external-services.md
@@ -74,11 +74,11 @@ $ rio external create ext foo:demo@v1
 To add externalservice pointing to app `demo` 
 
 ```bash
-$ rio external create `ext` demo
+$ rio external create ext demo
 ```
 
 To add externalservice pointing to route `prod`
 
 ```bash
-$ rio external create `ext` router/prod
+$ rio external create ext router/prod
 ```


### PR DESCRIPTION
Public domain and External Services v0.6.0 doc.