### PR TITLE
(rio up remoterepo) supporting provided path to Riofile and Riofile-answers relative to repo base, provide current namespace for dynamic configurations

### DIFF
--- a/cli/cmd/up/up.go
+++ b/cli/cmd/up/up.go
@@ -20,6 +20,7 @@ type Up struct {
 	Branch             string   `desc:"Set branch when pointing stack to git repo" default:"master"`
 	BuildCloneSecret   string   `desc:"Set git clone secret name"`
 	BuildWebhookSecret string   `desc:"Set GitHub webhook secret name"`
+	PushRegistrySecret string   `desc:"Set secret for pushing to custom registry"`
 	F_File             string   `desc:"Set rio file"`
 	Name               string   `desc:"Set stack name, defaults to current directory name"`
 	P_Parallel         bool     `desc:"Run builds in parallel"`
@@ -68,7 +69,9 @@ func (u *Up) setStack(c *clicontext.CLIContext, existing *riov1.Stack) error {
 		existing.Spec.Build.Revision = u.Revision
 		existing.Spec.Build.WebhookSecretName = u.BuildWebhookSecret
 		existing.Spec.Build.CloneSecretName = u.BuildCloneSecret
+		existing.Spec.Build.PushRegistrySecretName = u.PushRegistrySecret
 		existing.Spec.Permissions, err = stringers.ParsePermissions(u.Permission...)
+		existing.Spec.Build.Riofile = u.F_File
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/up/up.go
+++ b/cli/cmd/up/up.go
@@ -114,7 +114,7 @@ func (u *Up) loadFileAndAnswer(c *clicontext.CLIContext) (string, map[string]str
 	if answers == nil {
 		answers = map[string]string{}
 	}
-	answers["namespace"] = c.GetSetNamespace()
+	answers["NAMESPACE"] = c.GetSetNamespace()
 	content, err := up.LoadRiofile(u.F_File)
 	if err != nil {
 		return "", nil, err

--- a/cli/cmd/up/up.go
+++ b/cli/cmd/up/up.go
@@ -70,8 +70,9 @@ func (u *Up) setStack(c *clicontext.CLIContext, existing *riov1.Stack) error {
 		existing.Spec.Build.WebhookSecretName = u.BuildWebhookSecret
 		existing.Spec.Build.CloneSecretName = u.BuildCloneSecret
 		existing.Spec.Build.PushRegistrySecretName = u.PushRegistrySecret
-		existing.Spec.Permissions, err = stringers.ParsePermissions(u.Permission...)
 		existing.Spec.Build.Riofile = u.F_File
+		existing.Spec.Build.RiofileAnswers = u.Answers
+		existing.Spec.Permissions, err = stringers.ParsePermissions(u.Permission...)
 		if err != nil {
 			return err
 		}
@@ -110,7 +111,10 @@ func (u *Up) loadFileAndAnswer(c *clicontext.CLIContext) (string, map[string]str
 	if err != nil {
 		return "", nil, err
 	}
-
+	if answers == nil {
+		answers = map[string]string{}
+	}
+	answers["namespace"] = c.GetSetNamespace()
 	content, err := up.LoadRiofile(u.F_File)
 	if err != nil {
 		return "", nil, err

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -753,6 +753,7 @@ rio up [OPTIONS]
 | --revision value             |          | Use a specific commit hash                                               |         |
 | --build-webhook-secret value |          | Set GitHub webhook secret name                                           |         |
 | --build-clone-secret value   |          | Set name of secret to use with git clone                                 |         |
+| --push-registry-secret value |          | Set secret for pushing to custom registry                                |         |
 | --permission value           |          | Permissions to grant to container's service account in current namespace |         |
 
 ##### Examples

--- a/modules/build/controllers/stack/stack.go
+++ b/modules/build/controllers/stack/stack.go
@@ -92,12 +92,29 @@ func (p populator) populateBuild(stack *riov1.Stack, systemNamespace string, os 
 	if rev == "" {
 		return nil
 	}
+	rioUpArgs := []string{
+		"-n",
+		stack.Namespace,
+		"up",
+		"--name",
+		stack.Name,
+	}
+	if stack.Spec.Build.Riofile != "" {
+
+		rioUpArgs = append(rioUpArgs, "--file", stack.Spec.Build.Riofile)
+
+	}
 
 	trName := name.SafeConcatName(stack.Namespace, stack.Name+"-stack", name.Hex(stack.Spec.Build.Repo, 5), name.Hex(rev, 5))
 	sa := constructors.NewServiceAccount(stack.Namespace, trName+"-stack", corev1.ServiceAccount{})
 	if stack.Spec.Build.CloneSecretName != "" {
 		sa.Secrets = append(sa.Secrets, corev1.ObjectReference{
 			Name: stack.Spec.Build.CloneSecretName,
+		})
+	}
+	if stack.Spec.Build.PushRegistrySecretName != "" {
+		sa.Secrets = append(sa.Secrets, corev1.ObjectReference{
+			Name: stack.Spec.Build.PushRegistrySecretName,
 		})
 	}
 	os.Add(sa)
@@ -152,13 +169,7 @@ func (p populator) populateBuild(stack *riov1.Stack, systemNamespace string, os 
 							Command: []string{
 								"rio",
 							},
-							Args: []string{
-								"-n",
-								stack.Namespace,
-								"up",
-								"--name",
-								stack.Name,
-							},
+							Args: rioUpArgs,
 						},
 					},
 				},

--- a/modules/build/controllers/stack/stack.go
+++ b/modules/build/controllers/stack/stack.go
@@ -104,6 +104,11 @@ func (p populator) populateBuild(stack *riov1.Stack, systemNamespace string, os 
 		rioUpArgs = append(rioUpArgs, "--file", stack.Spec.Build.Riofile)
 
 	}
+	if stack.Spec.Build.RiofileAnswers != "" {
+
+		rioUpArgs = append(rioUpArgs, "--answers", stack.Spec.Build.RiofileAnswers)
+
+	}
 
 	trName := name.SafeConcatName(stack.Namespace, stack.Name+"-stack", name.Hex(stack.Spec.Build.Repo, 5), name.Hex(rev, 5))
 	sa := constructors.NewServiceAccount(stack.Namespace, trName+"-stack", corev1.ServiceAccount{})

--- a/pkg/apis/rio.cattle.io/v1/stack.go
+++ b/pkg/apis/rio.cattle.io/v1/stack.go
@@ -51,6 +51,9 @@ type StackBuild struct {
 	// Specify the name of the Riofile in the Repo. This is the full path relative to the repo root. Defaults to `Riofile`.
 	Riofile string `json:"rioFile,omitempty"`
 
+	// Specify the name of the Riofile-answers in the Repo. This is the full path relative to the repo root. Defaults to `Riofile`.
+	RiofileAnswers string `json:"rioFileAnswers,omitempty"`
+
 	// Specify the github secret name. Used to create Github webhook, the secret key has to be `accessToken`
 	WebhookSecretName string `json:"webhookSecretName,omitempty"`
 }

--- a/pkg/apis/rio.cattle.io/v1/stack.go
+++ b/pkg/apis/rio.cattle.io/v1/stack.go
@@ -45,6 +45,9 @@ type StackBuild struct {
 	// Git secret name for repository
 	CloneSecretName string `json:"cloneSecretName,omitempty"`
 
+	// Specify secret for pushing to custom registry
+	PushRegistrySecretName string `json:"pushRegistrySecretName,omitempty"`
+
 	// Specify the name of the Riofile in the Repo. This is the full path relative to the repo root. Defaults to `Riofile`.
 	Riofile string `json:"rioFile,omitempty"`
 


### PR DESCRIPTION
Closes rancher/rio#730 Closes rancher/rio##816

adds --push-registry-secret option to rio up, changes StackBuild spec