### PR TITLE
Add example of using an Riofile with k8s manifests

### DIFF
--- a/docs/v0.6.0/riofile.md
+++ b/docs/v0.6.0/riofile.md
@@ -13,9 +13,9 @@ configs:
       <!DOCTYPE html>
       <html>
       <body>
-      
+
       <h1>Hello World</h1>
-      
+
       </body>
       </html>
 services:
@@ -45,9 +45,9 @@ By default, Rio will poll the branch in 15 second intervals, but can be configur
 
 ```yaml
 # Configmap
-configs:          
-  config-foo:     # specify name in the section 
-    key1: |-      # specify key and data in the section 
+configs:
+  config-foo:     # specify name in the section
+    key1: |-      # specify key and data in the section
       {{ config1 }}
     key2: |-
       {{ config2 }}
@@ -64,10 +64,10 @@ externalservices:
 # Service
 services:
   service-foo:
-    
+
     # Scale setting
     scale: 2 # Specify scale of the service. If you pass range `1-10`, it will enable autoscaling which can be scale from 1 to 10. Default to 1 if omitted
-    
+
     # Revision setting
     app: my-app # Specify app name. Defaults to service name. This is used to aggregate services that belongs to the same app.
     version: v0 # Specify version name. Defaults to v0.
@@ -76,15 +76,15 @@ services:
     # Traffic rollout config. Optional
     rollout:
       increment: 5 # traffic percentage increment(%) for each interval.
-      interval: 2 # traffic increment interval(seconds). 
+      interval: 2 # traffic increment interval(seconds).
       pause: false # whether to perform rollout or not
 
     # Autoscaling setting. Only required if autoscaling is set
     concurrency: 10 # specify concurrent request each pod can handle(soft limit, used to scale service)
-    
+
     # Container configuration
     image: nginx # Container image. Required if not setting build
-    imagePullPolicy: always # Image pull policy. Options: (always/never/ifNotProsent), defaults to ifNotProsent. 
+    imagePullPolicy: always # Image pull policy. Options: (always/never/ifNotProsent), defaults to ifNotProsent.
     build: # Setting build parameters. Set if you want to build image for source
       repo: https://github.com/rancher/rio # Git repository to build. Required
       branch: master # Git repository branch. Required
@@ -109,10 +109,10 @@ services:
     workingDir: /home # Container working directory
     ports: # Container ports, format: `$(servicePort:)containerPort/protocol`. Required if user wants to expose service through gateway
     - 8080:80/http,web # Service port 8080 will be mapped to container port 80 with protocol http, named `web`
-    - 8080/http,admin,internal=true # Service port 8080 will be mapped to container port 8080 with protocol http, named `admin`, internal port(will not be exposed through gateway) 
+    - 8080/http,admin,internal=true # Service port 8080 will be mapped to container port 8080 with protocol http, named `admin`, internal port(will not be exposed through gateway)
     env: # Specify environment variable
-    - POD_NAME=$(self/name) # Mapped to "metadata.name" 
-    # 
+    - POD_NAME=$(self/name) # Mapped to "metadata.name"
+    #
     # "self/name":           "metadata.name",
     # "self/namespace":      "metadata.namespace",
     # "self/labels":         "metadata.labels",
@@ -122,12 +122,12 @@ services:
     # "self/hostIp":         "status.hostIP",
     # "self/nodeIp":         "status.hostIP",
     # "self/ip":             "status.podIP",
-    # 
+    #
     cpus: 100m # Cpu request, format 0.5 or 500m. 500m = 0.5 core. If not set, cpu request will not be set. https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     memory: 100Mi # Memory request. 100Mi, available options. If not set, memory request will not be set. https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     secrets: # Specify secret to mount. Format: `$name/$key:/path/to/file`. Secret has to be pre-created in the same namespace
     - foo/bar:/my/password
-    configs: # Specify configmap to mount. Format: `$name/$key:/path/to/file`. 
+    configs: # Specify configmap to mount. Format: `$name/$key:/path/to/file`.
     - foo/bar:/my/config
     livenessProbe: # LivenessProbe setting. https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
       httpGet:
@@ -146,11 +146,11 @@ services:
     runAsGroup: 1000 # The GID to run the entrypoint of the container process
     readOnlyRootFilesystem: true # Whether this container has a read-only root filesystem
     privileged: true # Run container in privileged mode.
-    
+
     nodeAffinity: # Describes node affinity scheduling rules for the pod.
     podAffinity:  # Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
     podAntiAffinity: # Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-    
+
     hostAliases: # Hostname alias
       - ip: 127.0.0.1
         hostnames:
@@ -158,8 +158,8 @@ services:
     hostNetwork: true # Use host networking, defaults to False. If this option is set, the ports that will be used must be specified.
     imagePullSecrets: # Image pull secret https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
     - secret1
-    - secret2 
-    
+    - secret2
+
     # Containers: Specify sidecars. Other options are available in container section above, this is limited example
     containers:
     - init: true # Init container
@@ -168,40 +168,40 @@ services:
       args:
       - "echo"
       - "hello world"
- 
+
 
     # Permission for service
-    # 
+    #
     #   global_permissions:
     #   - 'create,get,list certmanager.k8s.io/*'
-    #  
+    #
     #   this will give workload abilities to **create, get, list** **all** resources in api group **certmanager.k8s.io**.
     #
     #   If you want to hook up with an existing role:
     #
-    #   
+    #
     #   global_permissions:
     #   - 'role=cluster-admin'
-    #   
+    #
     #
     #   - `permisions`: Specify current namespace permission of workload
     #
-    #   Example: 
-    #   
+    #   Example:
+    #
     #   permissions:
     #   - 'create,get,list certmanager.k8s.io/*'
-    #  
     #
-    #   This will give workload abilities to **create, get, list** **all** resources in api group **certmanager.k8s.io** in **current** namespace. 
-    #   
-    #   Example: 
-    #   
+    #
+    #   This will give workload abilities to **create, get, list** **all** resources in api group **certmanager.k8s.io** in **current** namespace.
+    #
+    #   Example:
+    #
     #   permissions:
     #   - 'create,get,list /node/proxy'
-    #   
+    #
     #    This will give subresource for node/proxy
-    
-    # Optional, will created and mount serviceAccountToken into pods with corresponding permissions 
+
+    # Optional, will created and mount serviceAccountToken into pods with corresponding permissions
     global_permissions:
     - 'create,get,list certmanager.k8s.io/*'
     permissions:
@@ -212,7 +212,7 @@ routers:
   foo:
     routes:
       - match: # Match rules, the first rule matching an incoming request is used
-          path: # Match path, can specify regxp, prefix or exact match 
+          path: # Match path, can specify regxp, prefix or exact match
             exact: /v0
           # prefix: /bar
           # regxp: /bar.*
@@ -266,9 +266,9 @@ routers:
 # Use Riofile's answer/question templating
 template:
   goTemplate: true # use go templating
-  envSubst: true # use ENV vars during templating  
+  envSubst: true # use ENV vars during templating
   questions:  # now make some questions that we provide answers too
-  - variable: NAMESPACE 
+  - variable: NAMESPACE
     description: "namespace to deploy to"
   - variable: RIO_DEBUG
   - variable: RUN_API_VALIDATOR
@@ -280,4 +280,249 @@ kubernetes:
     kind: Deployment
     ....
 
-``` 
+```
+
+
+### How to use Rio to deploy an application with arbitary YAML
+_for Rio v0.6.0 and greater_
+
+In this example we will see how to define both a normal Rio service and arbitary Kubernetse manifests and deploy both of these with Rio. Follow the quickstart to get Rio installed into your cluster and ensure the output of `rio info` looks similar to this:
+```
+Rio Version:  >=0.6.0
+Rio CLI Version: >=0.6.0
+Cluster Domain: enu90s.on-rio.io
+Cluster Domain IPs: <cluster domain ip>
+System Namespace: rio-system
+System Ready State: true
+Wildcard certificates: true
+
+System Components:
+gateway-v2 status: Ready
+rio-controller status: Ready
+```
+
+First, lets use a Riofile to define a a basic Rio service.
+
+```
+configs:
+  conf:
+    index.html: |-
+      <!DOCTYPE html>
+      <html>
+      <body>
+
+      <h1>Hello World</h1>
+
+      </body>
+      </html>
+services:
+  nginx:
+    image: nginx
+    ports:
+    - 80/http
+    configs:
+    - conf/index.html:/usr/share/nginx/html/index.html
+```
+
+Next, we can augment this service with the Kubernetes [sample guestbook](https://kubernetes.io/docs/tutorials/stateless-application/guestbook/)
+
+
+```
+configs:
+    conf:
+        index.html: |-
+            <!DOCTYPE html>
+            <html>
+            <body>
+
+            <h1>Hello World</h1>
+
+            </body>
+            </html>
+services:
+    nginx:
+        image: nginx
+        ports:
+            - 80/http
+        configs:
+            - conf/index.html:/usr/share/nginx/html/index.html
+
+kubernetes:
+    manifest: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: redis-master
+        labels:
+          app: redis
+          tier: backend
+          role: master
+      spec:
+        ports:
+        - port: 6379
+          targetPort: 6379
+        selector:
+          app: redis
+          tier: backend
+          role: master
+---
+      apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: redis-master
+      spec:
+        selector:
+          matchLabels:
+            app: redis
+            role: master
+            tier: backend
+        replicas: 1
+        template:
+          metadata:
+            labels:
+              app: redis
+              role: master
+              tier: backend
+          spec:
+            containers:
+            - name: master
+              image: k8s.gcr.io/redis:e2e  # or just image: redis
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+              ports:
+              - containerPort: 6379
+---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: redis-slave
+        labels:
+          app: redis
+          tier: backend
+          role: slave
+      spec:
+        ports:
+        - port: 6379
+        selector:
+          app: redis
+          tier: backend
+          role: slave
+---
+      apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: redis-slave
+      spec:
+        selector:
+          matchLabels:
+            app: redis
+            role: slave
+            tier: backend
+        replicas: 2
+        template:
+          metadata:
+            labels:
+              app: redis
+              role: slave
+              tier: backend
+          spec:
+            containers:
+            - name: slave
+              image: gcr.io/google_samples/gb-redisslave:v1
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+              env:
+              - name: GET_HOSTS_FROM
+                value: dns
+                # If your cluster config does not include a dns service, then to
+                # instead access an environment variable to find the master
+                # service's host, comment out the 'value: dns' line above, and
+                # uncomment the line below:
+                # value: env
+              ports:
+              - containerPort: 6379
+---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: frontend
+        labels:
+          app: guestbook
+          tier: frontend
+      spec:
+        # if your cluster supports it, uncomment the following to automatically create
+        # an external load-balanced IP for the frontend service.
+        # type: LoadBalancer
+        ports:
+        - port: 80
+        selector:
+          app: guestbook
+          tier: frontend
+---
+      apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: frontend
+      spec:
+        selector:
+          matchLabels:
+            app: guestbook
+            tier: frontend
+        replicas: 3
+        template:
+          metadata:
+            labels:
+              app: guestbook
+              tier: frontend
+          spec:
+            containers:
+            - name: php-redis
+              image: gcr.io/google-samples/gb-frontend:v4
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+              env:
+              - name: GET_HOSTS_FROM
+                value: dns
+                # If your cluster config does not include a dns service, then to
+                # instead access environment variables to find service host
+                # info, comment out the 'value: dns' line above, and uncomment the
+                # line below:
+                # value: env
+              ports:
+              - containerPort: 80
+```
+
+Typically you would track your Riofile with some form of VCS but for now simply save it in a local directory.
+
+Next, run `rio up` in that directory.
+
+You can watch Rio service come up with `rio ps` and the kubernetes deployments with `kubectl get deployments -w`.
+
+You can check the sample service came up by going to the endpoint given by `rio ps`
+```
+NAME      IMAGE     ENDPOINT                                          SCALE     APP       VERSION    WEIGHT    CREATED       DETAIL
+nginx     nginx     https://nginx-2c21baa1-default.enu90s.on-rio.io   1         nginx     2c21baa1   100%      4 hours ago
+```
+
+We can use rio to expose the service and provision a LetsEncrypt certificate for it.
+
+` rio router add guestbook to frontend,port=80 `
+
+This will create a route to the service and create an endpoint.
+
+```
+rio endpoints
+NAME        ENDPOINTS
+nginx       https://nginx-default.enu90s.on-rio.io
+guestbook   https://guestbook-default.enu90s.on-rio.io
+```
+
+We can now access this endpoint over encrypted https!
+
+


### PR DESCRIPTION
Add an example using the kubernetes sample guestbook app to show how to
 use a Riofile with additional k8s yaml. Also show how to add a
 LetsEncrypt endpoint with Rio.