### PR TITLE
[Docs] Many small tweaks

### DIFF
--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -1,8 +1,8 @@
 # Autoscaling 
 
-Rio deploys a simple autoscaler to watch metrics from workloads and scale application based on current in-flight requests.
+Rio deploys a simple autoscaler to watch metrics from workloads and scale applications based on current in-flight requests.
 
-Note: Metric is scraped from linkerd-proxy sidecar, this requires your application to be injected with linkerd sidecar.
+Note: Metrics are scraped from the linkerd-proxy sidecar, this requires your application to be injected with the linkerd sidecar.
 This will happen by default when running new workloads.
 
 To enable autoscaling:
@@ -17,7 +17,7 @@ $ rio run --scale 1-10 --concurrency 20 -p 8080 strongmonkey1992/autoscale:v0
 $ rio run --scale 0-10 -p 8080 strongmonkey1992/autoscale:v0
 ```
 
-To put load the following example use [hey](https://github.com/rakyll/hey):
+To test putting load on the service, use [hey](https://github.com/rakyll/hey):
 
 ```bash
 hey -z 3m -c 60 http://xxx-xx.xxxxxx.on-rio-io
@@ -29,4 +29,4 @@ $ watch rio ps
 Note: `concurrency` means the maximum in-flight requests each pod can take. If your total in-flight request is 60 and concurrency 
 is 10, Rio will scale workloads to 6 replicas.
 
-Note: When scaling application to zero, the first request will take longer.
+Note: When scaling an application to zero, the first request will take longer.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -244,7 +244,7 @@ rio export --riofile namespace/default
 
 ## image
 
-List images built from local registry
+List images built from the local registry
 
 ##### Usage
 ```
@@ -293,7 +293,7 @@ rio inspect taskrun/affectionate-mirzakhani-mfp5q-ee709-4e40c
 
 ## install
 
-Install rio management plane
+Install the Rio management plane
 
 See the [install docs](install.md) for more info.
 
@@ -315,12 +315,12 @@ rio install [OPTIONS]
 
 **--check**
 
-Check if rio is installed in the current cluster without deploying rio controller.
-If rio has not been installed, this command might hang on `Waiting for rio controller to initialize`.
+Check if Rio is installed in the current cluster without deploying the Rio controller.
+If Rio has not been installed, this command might hang on `Waiting for rio controller to initialize`.
 
 **--disable-features**
 
-Choose features to be disabled when starting rio control plane. Below are a list of available features
+Choose features to be disabled when starting the Rio control plane. Below are a list of available features
 
 | Feature     | Description                                       |
 |-------------|---------------------------------------------------|
@@ -335,7 +335,7 @@ Choose features to be disabled when starting rio control plane. Below are a list
 **--ip-address**
 
 Manually specify IPAddress for API gateway services. The IP will be used to generate a record for the cluster domain.
-By default, if this flag is not specified, rio will use the IP of [Service Loadbalancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/) that points to API gateway.
+By default, if this flag is not specified, Rio will use the IP of [Service Loadbalancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/) that points to API gateway.
 
 Note: If service loadbalancer cannot be provisioned, [Nodeport](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) is used to expose API gateway.
 
@@ -667,7 +667,7 @@ rio stage --edit demo v2
 
 ## systemlogs
 
-Print the logs from Rio management plane
+Print the logs from the Rio management plane
 
 ##### Usage
 ```

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -23,7 +23,7 @@ on hostname, path, HTTP headers, protocol, and source.
 ### External Service
 
 External Service provides a way to register external IPs or hostnames in the service mesh so they can be accessed by Rio services.
-Also, rio services running in one namespace can be declared as ExternalServices in another namespace.
+Also, Rio services running in one namespace can be declared as ExternalServices in another namespace.
 
 ### Public Domain
 
@@ -31,8 +31,8 @@ Public Domain can be configured to assign a service or router a vanity domain li
 
 ### Cluster Domain
 
-Cluster Domain is a dns name that can be configured globally on each service so that each service will have an endpoint like $service_name-$namespace.xxx.clusterdomain.
-By default Rio will create and assign the `on-rio.io` dns name to each service, so it will have a dns name like `$name-$namespace.xxx.on-rio.io`.
+Cluster Domain is a DNS name that can be configured globally on each service so that each service will have an endpoint like $service_name-$namespace.xxx.clusterdomain.
+By default Rio will create and assign the `on-rio.io` DNS name to each service, so it will have a DNS name like `$name-$namespace.xxx.on-rio.io`.
 
 ### Configs
 
@@ -41,4 +41,4 @@ They are pieces of configuration that can be mounted into pods so that configura
 
 ### Secrets
 
-Secrets are a standard Kubernetes resource and can be referenced by rio services. They contain sensitive data that can be mounted into pods. 
+Secrets are a standard Kubernetes resource and can be referenced by Rio services. They contain sensitive data that can be mounted into pods. 

--- a/docs/continuous-deployment.md
+++ b/docs/continuous-deployment.md
@@ -1,41 +1,41 @@
 # Continuous Deployment
 
-Rio enables continuous deployment with Github by default.
+Rio enables continuous deployment with GitHub by default.
 This allows developers to streamline their focus on their git repository and worry less about their deploys.
 
 The most versatile use case is in [this example](#pull-request-builds).
 
 
 ### Basic Example
-Deploy a workload with rio from a public Github repository that you have push access to:
+Deploy a workload with Rio from a public GitHub repository that you have push access to:
 `rio run -n cd-demo -p 8080 https://github.com/rancher/rio-demo`
 
 Make a commit to the master branch of the repo. 
-You should notice that within 15 seconds, rio rebuilds your workload (`rio build history`) and updates it to match the committed changes.
+You should notice that within 15 seconds, Rio rebuilds your workload (`rio build history`) and updates it to match the committed changes.
 
 
 ### Advanced Usage
 #### Pull Request Builds
 This feature uses a webhook to create a deployment when submitting a Pull Request to your tracked branch (master by default).
-A new workload version will be staged in rio, associated to the same app that was initially created. 
-You can view the endpoint results directly from the PR by clicking "View deployment" in Github. 
-If the pull request is merged, it will then update the app endpoint in rio to point to this new version.
+A new workload version will be staged in Rio, associated to the same app that was initially created. 
+You can view the endpoint results directly from the PR by clicking "View deployment" in GitHub. 
+If the pull request is merged, it will then update the app endpoint in Rio to point to this new version.
 
 It only takes 2 steps:
 
 1. [Configure Webhook](./webhooks.md) for your repository. For this example, you only need to set the webhook up.
 2. `rio run -p 8080 -n example-cd --build-webhook-secret=githubtoken --build-pr --template https://github.com/example/example-repo`
 
-NOTE: if your repository is private, you will also need to [create credentials secret](#private-github-repo) and use the correct additional flags when running your workload.
+NOTE: if your repository is private, you will also need to [create a credentials secret](#private-github-repo) and use the correct additional flags when running your workload.
 
 
 #### Automatic Versioning
 Notice the `--template` flag specified in the [Pull Request Builds](#pull-request-builds) scenario.
-With this flag set, rio will automatically configure versions for this workload when new commits are pushed to the Github repo.
+With this flag set, Rio will automatically configure versions for this workload when new commits are pushed to the GitHub repo.
 As soon as the workload is ready, it will promote that version to have 100% of the app endpoint weight.
 The only case where it won't automatically promote is when using the `--build-pr` flag as well and the build is from the PR branch.
 
-If the `--template` flag is not set, then every subsequent build will overwrite the current version, including builds from PR branch with `--build-pr` flag set.
+If the `--template` flag is not set, then every subsequent build will overwrite the current version, including builds from the PR branch with `--build-pr` flag set.
 
 
 #### Private Github Repo
@@ -49,7 +49,7 @@ You can do this with Git Basic Auth or SSH Auth:
         username[]: $(your GH username)
         password[******]: $(your GH password)
         ```
-    2. Create workload pointing to your repo using standard git checkout. For example:
+    2. Create a workload pointing to your repo using standard git checkout. For example:
         `rio run -p 8080 https://github.com/example/example-private-repo`
 - SSH Auth:
     1. Configure git sshkey auth credential secrets. This should use a key that does not have a password associated to it:
@@ -64,7 +64,7 @@ You can do this with Git Basic Auth or SSH Auth:
 
 
 #### Private Docker Registry
-1. Configure docker credential secret.
+1. Configure the Docker credential secret.
 ```bash
 $ rio secret create --docker
 Select namespace[default]: $(put the same namespace with your workload)
@@ -72,12 +72,12 @@ Registry URL[https://index.docker.io/v1/]: $(found with "docker info | grep Regi
 username[]: $(your docker username)
 password[******]: $(your docker password)
 ```
-2. Create workload pointing to your image. For example:
+2. Create a workload pointing to your image. For example:
 `rio run --image-pull-secrets dockerconfig -p 8080 imageorg/imagename:version`
 
 
 ### Useful Options
-There are many options available for use when running workloads in rio. These are just a few that are useful for CD:
+There are many options available for use when running workloads in Rio. These are just a few that are useful for CD:
 
 | Option | Type | Description |
 |------|----| -------------|

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,6 +1,6 @@
 # Dashboard 
 
-Rio ships with a built-in dashboard. To enable dashboard:
+Rio ships with a built-in dashboard. To enable the dashboard:
 
 ```bash
 $ rio dashboard

--- a/docs/developing-application-using-rio.md
+++ b/docs/developing-application-using-rio.md
@@ -1,6 +1,6 @@
 # Developing application using Rio
 
-Rio CLI provides an easy way to build and deploy your applications into a k8s cluster. It takes advantage of [Riofile](./riofile.md) and [buildkit](https://github.com/moby/buildkit) to
+The Rio CLI provides an easy way to build and deploy your applications into a Kubernetes cluster. It takes advantage of [Riofile](./riofile.md) and [buildkit](https://github.com/moby/buildkit) to
 build images and update deployments with them.
 
 #### Using Riofile to develop applications
@@ -34,7 +34,7 @@ services:
 $ rio up
 ```
 
-5. Check with `rio ps`. It should create a service with URL serving the content. It should be serving Blue cows.
+5. Check with `rio ps`. It should create a service with URL serving the content. It should be serving blue cows.
 
 6. Open the `Dockerfile` and change `ENV COW_COLOR` from `blue` to `red`.
 
@@ -46,7 +46,7 @@ By following the example above, you can now develop your code locally and run `r
 
 #### Manually build and run
 
-You can also use Rio CLI to build and run image locally in your cluster.
+You can also use the Rio CLI to build and run an image locally in your cluster.
 
 1. Go to the root directory of repo and run
 
@@ -54,7 +54,7 @@ You can also use Rio CLI to build and run image locally in your cluster.
 $ rio build
 ```
 
-2. Wait for image to be built. Once it is done, run
+2. Wait for the image to be built. Once it is done, run
 
 ```bash
 $ rio images

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,13 +1,13 @@
 # FAQs 
 
-Frequently asked questions about working with rio
+Frequently asked questions for Rio
 ##
 
 **Q:** What Kubernetes version do I need to run rio?
 
-**A:** We recommend using [k3s](https://k3s.io/)! 
-Rio should work with any kubernetes version v1.15+. If using a managed kubernetes instance, use the latest version available. 
-We have internally tested major features of rio with GKE v1.14.8-gke.12 and EKS v1.14.8-eks-b7174d.
+**A:** We recommend using [K3s](https://k3s.io/)! 
+Rio should work with any Kubernetes version v1.15+. If using a managed Kubernetes instance, use the latest version available. 
+We have internally tested major features of Rio with GKE v1.14.8-gke.12 and EKS v1.14.8-eks-b7174d.
 ##
 
 **Q:** Why doesn't the first workload I create have a version but staged workloads do?
@@ -15,7 +15,7 @@ We have internally tested major features of rio with GKE v1.14.8-gke.12 and EKS 
 **A:** The first workload you create is always `v0` by default, and this is hidden in the CLI to avoid clutter.
 ##
 
-**Q:** Why is the Rio cli stuck when I run a command?
+**Q:** Why is the Rio CLI stuck when I run a command?
 
 **A:** Verify you have used an available option and don't have any typos. 
 If you are sure there are no typos in your command, feel free to submit an issue with the exact command and options you used.
@@ -29,7 +29,7 @@ If you are sure there are no typos in your command, feel free to submit an issue
 **Q:** Why can't I remove services that were created with a Riofile?
 
 **A:** If you wish to delete ALL resources associated to the stack, delete the stack itself:
-1. Obtain stack name: `rio stacks`
+1. Obtain the stack name: `rio stacks`
 2. Delete it: `rio rm <stack name>`
 
 If instead you wish to remove a specific resource, then remove it from the Riofile and reapply it: `rio up`

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Install Rio
 
-Rio can be installed from both CLI or kubernetes manifest.
+Rio can be installed from both the CLI or a Kubernetes manifest.
 
 1. Download the latest release. 
 
@@ -8,13 +8,13 @@ Rio can be installed from both CLI or kubernetes manifest.
 $ curl -sfL https://get.rio.io | sh - 
 ```
 
-Note: by default it will only download the latest release from github. To test a pre-release or alpha build, run.
+Note: by default the script will only download the latest release from GitHub. To test a pre-release or alpha build, run.
 
 ```bash
 $ curl -sfL https://get.rio.io | INSTALL_RIO_VERSION=${version} sh - 
 ```
 
-2. Prepare a Kubernetes cluster, see [Clusters and Providers](#clusters-and-providers). Setup KUBECONFIG environment variable to point to your kubernetes cluster.
+2. Prepare a Kubernetes cluster, see [Clusters and Providers](#clusters-and-providers). Set the KUBECONFIG environment variable to point to your Kubernetes cluster.
 
 3. Run 
 
@@ -22,8 +22,8 @@ $ curl -sfL https://get.rio.io | INSTALL_RIO_VERSION=${version} sh -
 $ rio install
 ```
 
-Note: to install rio from kubernetes manifest, run `rio install --yaml`. It will print out kubernetes manifest instead of 
-installing rio directly, so that you can apply the manifest later.
+Note: to install Rio a Kubernetes manifest, run `rio install --yaml`. It will print out the Kubernetes manifest instead of 
+installing Rio directly, so that you can apply the manifest later.
 
 ## Options
 
@@ -31,24 +31,24 @@ See the [CLI install reference docs](cli-reference.md#install) for complete list
 
 ## Clusters and Providers
 
-A 1.15 or higher version of kubernetes is recommended.
+A 1.15 or higher version of Kubernetes is recommended.
 
-See the kubernetes [getting started guide](https://kubernetes.io/docs/setup/) to help choose a cluster type.
+See the Kubernetes [getting started guide](https://kubernetes.io/docs/setup/) to help choose a cluster type.
 
 **Internal vs external IP address**
 
 Some cloud providers will use an internal IP address by default and Rio will use that for its cluster domain.
 You can override this during cluster setup by configuring external IP's, or by using a cloud-provider to setup a load balancer which will have an external IP.
 
-For an example of installing a cluster with a cloud provider on Linode using Rancher, see [bullet #8 on this doc](https://www.linode.com/docs/kubernetes/how-to-deploy-kubernetes-on-linode-with-rancher-2-x/#provision-a-cluster).
+For an example of installing a cluster with a cloud provider on Linode using Rancher, see [step #8 on this doc](https://www.linode.com/docs/kubernetes/how-to-deploy-kubernetes-on-linode-with-rancher-2-x/#provision-a-cluster).
 
-**k3s**
+**K3s**
 
-When installing on k3s use the `--no-deploy traefik` flag.
+When installing on K3s use the `--no-deploy traefik` flag.
 
 **EKS**
 
-Ensure you are running enough nodes with proper instance types to allow for the rio and kubernetes systems to run at least 45 pods.
+Ensure you are running enough nodes with proper instance types to allow for the Rio and Kubernetes systems to run at least 45 pods.
 See the docs to help determine proper sizes:
 
 * Guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,10 +1,10 @@
 # Monitoring 
 
-Rio deploys [linkerd](https://linkerd.io/) to collect metrics from workloads. You can use Rio dashboard or linkerd dashboard to monitor traffic for your applications.
+Rio deploys [linkerd](https://linkerd.io/) to collect metrics from workloads. You can use the Rio dashboard or linkerd dashboard to monitor traffic for your applications.
 
 To run Rio dashboard, check [here](./dashboard.md).
 
-To run linkerd dashboard:
+To run the linkerd dashboard:
 
 ```bash
 $ rio linkerd

--- a/docs/publicdomain-external-services.md
+++ b/docs/publicdomain-external-services.md
@@ -4,7 +4,7 @@ Rio allows you to add a vanity domain, such as `www.myproductionsite.com`, to yo
 
 For example:
 
-1. Setup a CNAME record from your domain to rio cluster domain. You should be able to see cluster domain when running `rio info`.
+1. Setup a CNAME record from your domain to the Rio cluster domain. You should be able to see the cluster domain when running `rio info`.
 
     myproduction.com -----> CNAME -------> xxxxxx.on-rio.io
 
@@ -22,25 +22,25 @@ $ rio endpoint
 
 In the above example, `$target` can be a service(`app@version`), a group of services(`app`) or a router(`router`)
 
-For example, to register domain with app `demo` and version `v1`:
+For example, to register a domain with app `demo` and version `v1`:
 
 ```bash
 $ rio domain register myproductionsite.com demo@v1
 ```
 
-To register domain with app `demo`:
+To register a domain with app `demo`:
 
 ```bash
 $ rio domain register  myproductionsite.com demo
 ```
 
-To register domain with router `prod`:
+To register a domain with router `prod`:
 
 ```bash
 $ rio domain register  myproductionsite.com router/prod
 ```
 
-To unregister domain:
+To unregister a domain:
 
 ```bash
 $ rio unregister publicdomain/myproductionsite.com 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,7 +3,7 @@ Exposing the service requires passing the `-p` flag to expose ports from the con
 
 ---
 
-#### Running a container from a docker image
+#### Running a container from a Docker image
 
 ```bash
 $ rio run -p 80 --name demo nginx
@@ -15,9 +15,9 @@ $ rio ps
 curl https://demo-v0-default.xxxxx.on-rio.io
 ```
 
-#### Running a container from a github repository
-Rio allows user to run a container directly from source code. 
-By pointing to git repository that contains a Dockerfile, Rio will clone the source code, build the docker image, and deploy it into the cluster.
+#### Running a container from a GitHub repository
+Rio allows a user to run a container directly from source code. 
+By pointing to git repository that contains a Dockerfile, Rio will clone the source code, build the Docker image, and deploy it into the cluster.
 Also Rio will watch for changes to the repo and automatically update the deployment.
 
 ```bash

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -2,7 +2,7 @@
 
 Rio can be configured and used in a multi-tenant environment while providing the best practices for security.
 
-This section requires basic knowledge of kubernetes RBAC. To understand kubernetes RBAC, go [here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+This section requires basic knowledge of Kubernetes RBAC. To learn more about RBAC, go [here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
 By default Rio creates four roles `rio-admin`, `rio-privileged`, `rio-readonly`, `rio-standard`. Detailed permissions can be found in [here](https://github.com/rancher/rio/blob/master/stacks/rio-bootstrap-stack.yaml).
 

--- a/docs/riofile.md
+++ b/docs/riofile.md
@@ -4,7 +4,7 @@
 Rio works with standard Kubernetes YAML files. Rio additionally supports a more user-friendly `docker-compose`-style config file called `Riofile`.
 This allows you define rio services, routes, external services, configs, and secrets.
 
-For example, this is an example of an nginx application:
+For example, here is an nginx application:
 
 ```yaml
 configs:
@@ -28,7 +28,7 @@ services:
 ```
 
 Once you have defined `Riofile`, simply run `rio up`.
-Any change you made for `Riofile`, re-run `rio up` to pick the change.
+If you made any change to the `Riofile`, re-run `rio up` to pick up the change.
 To use a file not named "Riofile" use `rio up -f nginx.yaml`.
 
 #### Watching Riofile
@@ -38,7 +38,7 @@ You can setup Rio to watch for Riofile changes in a Github repository and deploy
 $ rio up https://github.com/username/repo
 ```
 
-By default, Rio will poll the branch in 15 second intervals, but can be configured to use a webhook instead. See [Webhook docs](./webhooks.md) for info.
+By default, Rio will poll the branch in 15 second intervals, but this can be configured to use a webhook instead. See [Webhook docs](./webhooks.md) for info.
 
 #### Riofile reference
 
@@ -499,15 +499,15 @@ Typically you would track your Riofile with some form of VCS but for now simply 
 
 Next, run `rio up` in that directory.
 
-You can watch Rio service come up with `rio ps` and the kubernetes deployments with `kubectl get deployments -w`.
+You can watch Rio service come up with `rio ps` and the Kubernetes deployments with `kubectl get deployments -w`.
 
-You can check the sample service came up by going to the endpoint given by `rio ps`
+You can check that the sample service came up by going to the endpoint given by `rio ps`
 ```
 NAME      IMAGE     ENDPOINT                                          SCALE     APP       VERSION    WEIGHT    CREATED       DETAIL
 nginx     nginx     https://nginx-2c21baa1-default.enu90s.on-rio.io   1         nginx     2c21baa1   100%      4 hours ago
 ```
 
-We can use rio to expose the service and provision a LetsEncrypt certificate for it.
+We can use Rio to expose the service and provision a LetsEncrypt certificate for it.
 
 ` rio router add guestbook to frontend,port=80 `
 
@@ -525,7 +525,7 @@ We can now access this endpoint over encrypted https!
 
 #### Using answer file 
 
-Rio allows user to answer file to customize `Riofile`. Go template and [envSubst](https://github.com/drone/envsubst) can used to apply answers.
+Rio allows the user to leverage an answer file to customize `Riofile`. Go template and [envSubst](https://github.com/drone/envsubst) can used to apply answers.
 
 Answer file is a yaml manifest with key-value pairs:
 

--- a/docs/router.md
+++ b/docs/router.md
@@ -11,7 +11,7 @@ $ rio [-n $namespace] route add $name to $target
 ```
 
 Note: $name will be the router name. $target can point to individual services or a group of services.
-Target service has to be in the same namespace as the router.
+The target service has to be in the same namespace as the router.
 
 For example, to point to app `demo` and version `v1`:
 
@@ -19,7 +19,7 @@ For example, to point to app `demo` and version `v1`:
 $ rio route add prod to demo@v1
 ```
 
-To point to all weighted versions of app `demo`
+To point to all weighted versions of app `demo`:
 
 ```bash
 $ rio route add prod to demo
@@ -59,7 +59,7 @@ $ rio route add --header USER=VALUE $name to $target
 
 #### Route Based on HTTP Method
 
-Create route based on HTTP method
+Create route based on HTTP method:
 ```bash
 $ rio route add --method GET $name to $target
 ```
@@ -85,7 +85,7 @@ $ rio route add $name mirror $target
 
 #### Rewrite to host/path
 
-Rewrite host header and path
+Rewrite host header and path:
 ```bash
 $ rio route add $name rewrite $rewrite_host/$rewrite_path
 ```
@@ -93,7 +93,7 @@ $ rio route add $name rewrite $rewrite_host/$rewrite_path
 
 #### Redirect
 
-Redirect to another service
+Redirect to another service:
 ```bash
 $ rio route add $name redirect $target_service/path
 ```
@@ -101,7 +101,7 @@ $ rio route add $name redirect $target_service/path
 
 #### Timeout
 
-Add timeout
+Add timeout:
 ```bash
 $ rio route add --timeout-seconds $value $name to $target
 ```
@@ -109,7 +109,7 @@ $ rio route add --timeout-seconds $value $name to $target
 
 #### Fault injection
 
-Add fault injection
+Add fault injection:
 ```bash
 $ rio route add --fault-httpcode 502 --fault-delay-milli-seconds 1000 --fault-percentage 80 $name to $target
 ```
@@ -117,7 +117,7 @@ $ rio route add --fault-httpcode 502 --fault-delay-milli-seconds 1000 --fault-pe
 
 #### Retry logic
 
-Add retry logic
+Add retry logic:
 ```bash
 $ rio route add --retry-attempts 5 --retry-timeout-seconds 1s $name to $target
 ```
@@ -125,7 +125,7 @@ $ rio route add --retry-attempts 5 --retry-timeout-seconds 1s $name to $target
 
 #### Split traffic in router
 
-Create router to different revision and different weight
+Create router to different revision and different weight:
 ```bash
 $ rio route add $name to $service@v0,weight=50 $service@v1,weight=50
 ```
@@ -133,7 +133,7 @@ $ rio route add $name to $service@v0,weight=50 $service@v1,weight=50
 
 #### Insert Rules
 
-Insert a router rule instead of append so that it will be evaluated first
+Insert a router rule instead of append so that it will be evaluated first:
 ```bash
 $ rio route add --insert $name to $target
 ```

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,9 +1,9 @@
 # Webhook
 
-By default, rio will automatically poll git repo and check if code has changed.
+By default, Rio will automatically poll the git repo and check if code has changed.
 You can also configure a webhook to automatically push any events to Rio to trigger the build.
 
-1. Set up Github webhook token.
+1. Set up the GitHub webhook token.
 ```
 $ rio secret add --github-webhook
 Select namespace[default]: $(put the same namespace with your workload)
@@ -11,21 +11,21 @@ accessToken: $(github_accesstoken) # the token has to be able create webhook in 
 Create workload and point to your repo.
 ```
 
-2. Create workload and point to your repo
+2. Create a workload and point to your repo
 ```
 rio run -p 80 --build-webhook-secret=githubtoken https://github.com/example/example
 ```
 
-3. Go to your Github repo, it should have webhook configured to point to one of our webhook service.
+3. Go to your GitHub repo, it should have the webhook configured to point to one of the webhook services.
 
 # Webhook for Riofile
 
-Setup webhook and private git clone secret for git repository that contains Riofile:
+Set up the webhook and private git clone secret for the git repository that contains Riofile:
 
 ```bash
 $ rio up --build-clone-secret gitsecret --build-webhook-secret webhook https://github.com/example/example
 ```
 
-For how to add git and webhook secret, check [here](./continuous-deployment.md).
+For how to add the git and webhook secret, check [here](./continuous-deployment.md).
 
 Note: `Riofile` and `Riofile-answers` in the root directory are automatically applied.

--- a/docs/workloads.md
+++ b/docs/workloads.md
@@ -1,6 +1,6 @@
 # Running workloads
 
-### Deploying Container Into Rio
+### Deploying a Container Into Rio
 
 ```bash
 # Exposing the service requires passing the `-p` flag to expose ports from the container
@@ -18,12 +18,12 @@ a certificate for the cluster domain so that all services support HTTPS by defau
 For example, when you deploy your workload, you can access your workload in HTTPS. The domain always follows the format
 of ${app}-${namespace}.\${cluster-domain}. You can see your cluster domain by running `rio info`.
 
-Note: If linkerd feature is enabled, Rio will automatically inject linkerd-proxy into your workload. If you would like to disable that, run `rio run --no-mesh`.
+Note: Linkerd is enabled by default, so Rio will automatically inject linkerd-proxy into your workload. If you would like to disable that, run `rio run --no-mesh`.
 
 ### Expose your service
 
-Note: In order to expose your service you have pass the flag `--port`(shorthand `-p`). The format is `[service_port:]container_port[/protocol]`
-If you don't pass port the service will be private by default (only accessible inside cluster).
+Note: In order to expose your service you have to pass the flag `--port`(shorthand `-p`). The format is `[service_port:]container_port[/protocol]`
+If you don't pass the flag, the service will be private by default (only accessible inside the cluster).
 
 ```bash
 # To expose services through 80/http
@@ -86,10 +86,10 @@ $ rio run --net=host nginx
 For more examples, check [here](./cli-reference.md)
 
 ### Split Traffic Between Revisions
-Rio natively supports splitting traffic between revisions. Splitting Traffic can be quite useful in canary deployment, Blue/Green deployment and A/B testing. 
+Rio natively supports splitting traffic between revisions. Splitting Traffic can be quite useful in a canary deployment, a Blue/Green deployment and A/B testing. 
 
 Each Rio service you deploy will have two unique label identifiers across current namespace: `app` and `version`.
-Based on `app` and `version` user is allowed to assign weight between each revision to manage traffic.
+Based on `app` and `version`, the user is allowed to assign weight between each revision to manage traffic.
 
 To deploy a demo application with version v1
 
@@ -117,11 +117,11 @@ $ rio endpoints
 NAME              ENDPOINTS
 demo              https://demo-default.xxxxxx.on-rio.io
 ```
-Note: This endpoint will only return versions that have weight greater than 0%. Versions with a higher weight percentage will be returned more often.
+Note: This endpoint will only return versions that have a weight greater than 0%. Versions with a higher weight percentage will be returned more often.
 
 #### Assign weight between each revision
 
-Now assign weight 50% to demo@v3
+Now assign a weight of 50% to demo@v3
 
 ```bash
 # Weight is immediately assigned by default
@@ -134,27 +134,27 @@ $ rio weight --duration 10m demo@v3=50%
 $ rio promote demo@v3
 ```
 
-Note: services are discoverable inside cluster by their short DNS name. For example services demo@v1 and demo@v3 are discoverable through
+Note: services are discoverable inside the cluster by their short DNS name. For example services demo@v1 and demo@v3 are discoverable through
 `demo-v1` and `demo-v3`. `demo` is also discoverable to serve traffic from both versions.
 
-### Running Stateful Application (experimental)
+### Running Stateful Applications (experimental)
 
-Rio supports running stateful applications by leveraging kubernetes [persistentvolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
+Rio supports running stateful applications by leveraging Kubernetes' [persistentvolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
 
 
-To mount a volume into container (By default it will create [emptydir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume):
+To mount a volume into a container (By default it will create an [emptydir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume):
 
 ```bash
 $ rio run -v foo:/data nginx
 ```
 
-To mount a persistent volume into container (By default it will create persistent volume if cluster has default storageclass, otherwise it will use existing pvc with the same name):
+To mount a persistent volume into a container (By default it will create a persistent volume if the cluster has a default storageclass, otherwise it will use the existing pvc with the same name):
 
 ```bash
 $ rio run -v foo:/data,persistent=true nginx
 ```
 
-To mount a hostpath volume into container
+To mount a hostpath volume into a container
 
 ```bash
 $ rio run -v foo:/etc,hosttype=directoryorcreate nginx


### PR DESCRIPTION
- Capitalize rio > Rio where appropriate
- Capitalize kubernetes > Kubernetes where appropraite
- Capitalize docker > Docker where appropriate
- Fix capitalization of github > GitHub where appropriate
- Fix areas were articles were not utilized ("a", "an", "the") where appropriate
- Various grammar tweaks and nitpicks