### PR TITLE
[0.6.x] CLI and controller updates for weights and rollouts

### DIFF
--- a/cli/cmd/create/create.go
+++ b/cli/cmd/create/create.go
@@ -69,7 +69,7 @@ type Create struct {
 	P_Ports                []string          `desc:"Publish a container's port(s) (format: svcport:containerport/protocol)"`
 	Privileged             bool              `desc:"Run container with privilege"`
 	ReadOnly               bool              `desc:"Mount the container's root filesystem as read only"`
-	RolloutDuration        string            `desc:"How long the rollout should take" default:"0s"`
+	RolloutDuration        string            `desc:"How long the rollout should take.  An approximation, actual time may fluctuate" default:"0s"`
 	RequestTimeoutSeconds  int               `desc:"Set request timeout in seconds"`
 	Scale                  string            `desc:"The number of replicas to run or a range for autoscaling (example 1-10)"`
 	Secret                 []string          `desc:"Secrets to inject to the service (format: name[/key]:target)"`
@@ -103,15 +103,12 @@ func (c *Create) RunCallback(ctx *clicontext.CLIContext, cb func(service *riov1.
 		return nil, err
 	}
 	if c.Weight == 100 {
-		err = weight.PromoteService(ctx, types.Resource{
+		return service, weight.PromoteService(ctx, types.Resource{
 			Name:      service.Name,
 			App:       service.Spec.App,
 			Version:   service.Spec.Version,
 			Namespace: service.Namespace,
 		}, service.Spec.RolloutConfig, *service.Spec.Weight)
-		if err != nil {
-			return service, err
-		}
 	}
 	return service, nil
 }

--- a/cli/cmd/create/create.go
+++ b/cli/cmd/create/create.go
@@ -203,6 +203,10 @@ func (c *Create) ToService(ctx *clicontext.CLIContext, args []string) (*riov1.Se
 		spec.ServiceMesh = &mesh
 	}
 
+	if c.Weight > 100 {
+		return nil, fmt.Errorf("weight cannot exceed 100")
+	}
+
 	if c.Weight > 0 {
 		duration, err := time.ParseDuration(c.RolloutDuration)
 		if err != nil {

--- a/cli/cmd/promote/promote.go
+++ b/cli/cmd/promote/promote.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Promote struct {
-	Duration string `desc:"How long the rollout should take" default:"0s"`
+	Duration string `desc:"How long the rollout should take. An approximation, actual time may fluctuate" default:"0s"`
 	Pause    bool   `desc:"Whether to pause rollout or continue it. Default to false" default:"false"`
 }
 

--- a/cli/cmd/ps/ps_services.go
+++ b/cli/cmd/ps/ps_services.go
@@ -1,10 +1,10 @@
 package ps
 
 import (
-	"math"
 	"strings"
 
 	webhookv1 "github.com/rancher/gitwatcher/pkg/apis/gitwatcher.cattle.io/v1"
+	cliWeight "github.com/rancher/rio/cli/cmd/weight"
 	"github.com/rancher/rio/cli/pkg/clicontext"
 	"github.com/rancher/rio/cli/pkg/tables"
 	clitypes "github.com/rancher/rio/cli/pkg/types"
@@ -130,7 +130,7 @@ func (p *Ps) services(ctx *clicontext.CLIContext) error {
 					totalWeight += *subService.(*riov1.Service).Status.ComputedWeight
 				}
 			}
-			weight = int(math.Round((float64(*service.(*riov1.Service).Status.ComputedWeight) / float64(totalWeight)) / 0.01)) // round to nearest percent
+			weight = cliWeight.CalcWeightPercentage(*service.(*riov1.Service).Status.ComputedWeight, totalWeight)
 		}
 
 		var gitwatcher *webhookv1.GitWatcher

--- a/cli/cmd/weight/weight.go
+++ b/cli/cmd/weight/weight.go
@@ -178,7 +178,7 @@ func validateArg(arg string) (string, int, error) {
 		return serviceName, scale, fmt.Errorf("failed to parse %s: %v", arg, err)
 	}
 	if scale > 100 {
-		return serviceName, scale, fmt.Errorf("scale cannot exceed 100")
+		return serviceName, scale, fmt.Errorf("weight cannot exceed 100")
 	}
 	return serviceName, scale, nil
 }

--- a/cli/cmd/weight/weight.go
+++ b/cli/cmd/weight/weight.go
@@ -25,7 +25,7 @@ const (
 )
 
 type Weight struct {
-	Duration string `desc:"How long the rollout should take" default:"0s"`
+	Duration string `desc:"How long the rollout should take. An approximation, actual time may fluctuate" default:"0s"`
 	Pause    bool   `desc:"Whether to pause rollout or continue it. Default to false" default:"false"`
 }
 

--- a/cli/cmd/weight/weight.go
+++ b/cli/cmd/weight/weight.go
@@ -95,33 +95,18 @@ func GenerateWeightAndRolloutConfig(ctx *clicontext.CLIContext, obj types.Resour
 			totalCurrWeight += *s.Status.ComputedWeight
 		}
 	}
-	if targetPercentage == int(math.Round(float64(currComputedWeight)/float64(totalCurrWeight)/0.01)) {
+	if targetPercentage == CalcWeightPercentage(currComputedWeight, totalCurrWeight) {
 		return 0, nil, errors.New("cannot rollout, already at target percentage")
 	}
 	totalCurrWeightOtherSvcs := totalCurrWeight - currComputedWeight
-
-	newComputedWeight := targetPercentage
-	if targetPercentage == 100 {
-		newComputedWeight = PromoteWeight
-	} else if totalCurrWeightOtherSvcs > 0 {
-		// find the weight that would hit our target percentage without touching other service weights
-		// ie: if 2 svcs at 50/50 and you want one at 75%, newComputedWeight would be 150
-		newComputedWeight = int(float64(totalCurrWeightOtherSvcs)/(1-(float64(targetPercentage)/100))) - totalCurrWeightOtherSvcs
-	}
+	newComputedWeight := calcComputedWeight(targetPercentage, totalCurrWeightOtherSvcs)
 
 	// if not immediate rollout figure out increment
 	increment := 0
 	if duration.Seconds() >= 2.0 {
-		steps := duration.Seconds() / float64(DefaultInterval)         // First get rough amount of steps we want to take
-		totalNewWeight := totalCurrWeightOtherSvcs + newComputedWeight // Given the future total weight which includes our newWeight...
-		difference := totalNewWeight - totalCurrWeight                 // Find the difference between future total weight and current total weight
-		if targetPercentage == 100 {
-			difference = PromoteWeight // In this case the future total weight is now only our newComputedWeight and difference is always 1k
-		}
-		increment = int(math.Abs(math.Round(float64(difference) / steps))) // And divide by steps to get rough increment
-
-		if increment == 0 { // Error out if increment was below 1, and thus rounded to 0
-			return 0, nil, errors.New("Unable to perform rollout, given duration too long for current weight")
+		increment, err = calcIncrement(duration, targetPercentage, totalCurrWeight, totalCurrWeightOtherSvcs)
+		if err != nil {
+			return 0, nil, err
 		}
 	}
 	rolloutConfig := &riov1.RolloutConfig{
@@ -196,5 +181,48 @@ func promotedSvcNeedsUpdate(svc *riov1.Service, weight int, rc *riov1.RolloutCon
 		return true
 	}
 	return false
+
+}
+
+// Get curr weight as percentage, rounded to nearest percent
+func CalcWeightPercentage(weight, totalWeight int) int {
+	if totalWeight == 0 || weight == 0 {
+		return 0
+	}
+	return int(math.Round(float64(weight) / float64(totalWeight) / 0.01))
+}
+
+// Find the weight that would hit our target percentage without touching other service weights
+// ie: if 2 svcs at 50/50 and you want one at 75%, newComputedWeight would be 150
+func calcComputedWeight(targetPercentage int, totalCurrWeightOtherSvcs int) int {
+	if targetPercentage == 100 {
+		return PromoteWeight
+	} else if totalCurrWeightOtherSvcs > 0 {
+		return int(float64(totalCurrWeightOtherSvcs)/(1-(float64(targetPercentage)/100))) - totalCurrWeightOtherSvcs
+	}
+	return targetPercentage
+}
+
+// Determine increment we should step by given duration
+// Note that we don't care (because blind to direction of scaling) if increment is larger than newComputedWeight, rollout controller will handle overflow case
+func calcIncrement(duration time.Duration, targetPercentage, totalCurrWeight, totalCurrWeightOtherSvcs int) (int, error) {
+	steps := duration.Seconds() / float64(DefaultInterval) // First get rough amount of steps we want to take
+	if steps < 1.0 {
+		steps = 1.0
+	}
+	newComputedWeight := calcComputedWeight(targetPercentage, totalCurrWeightOtherSvcs)
+	totalNewWeight := totalCurrWeightOtherSvcs + newComputedWeight // Given the future total weight which includes our newWeight...
+	difference := totalNewWeight - totalCurrWeight                 // Find the difference between future total weight and current total weight
+	if targetPercentage == 100 {
+		difference = PromoteWeight // In this case the future total weight is now only our newComputedWeight and difference is always 1k
+	}
+	if difference == 0 {
+		return 0, nil // if there is no difference return now so we don't error out below
+	}
+	increment := int(math.Abs(math.Round(float64(difference) / steps))) // Divide by steps to get rough increment
+	if increment == 0 {                                                 // Error out if increment was below 1, and thus rounded to 0
+		return 0, errors.New("unable to perform rollout, given duration too long for current weight")
+	}
+	return increment, nil
 
 }

--- a/cli/cmd/weight/weight_test.go
+++ b/cli/cmd/weight/weight_test.go
@@ -1,0 +1,224 @@
+package weight
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_calcComputedWeight(t *testing.T) {
+	type args struct {
+		targetPercentage         int
+		totalCurrWeightOtherSvcs int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "basic 50/50 calc",
+			args: args{
+				targetPercentage:         50,
+				totalCurrWeightOtherSvcs: 50,
+			},
+			want: 50,
+		},
+		{
+			name: "basic 50/75 calc",
+			args: args{
+				targetPercentage:         75,
+				totalCurrWeightOtherSvcs: 50,
+			},
+			want: 150,
+		},
+		{
+			name: "attempt to promote always gives same answer",
+			args: args{
+				targetPercentage:         100,
+				totalCurrWeightOtherSvcs: 100,
+			},
+			want: 10000,
+		},
+		{
+			name: "basic zero scale",
+			args: args{
+				targetPercentage:         0,
+				totalCurrWeightOtherSvcs: 100,
+			},
+			want: 0,
+		},
+		{
+			name: "return target percentage when no weight",
+			args: args{
+				targetPercentage:         50,
+				totalCurrWeightOtherSvcs: 0,
+			},
+			want: 50,
+		},
+		{
+			name: "small case",
+			args: args{
+				targetPercentage:         50,
+				totalCurrWeightOtherSvcs: 1,
+			},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calcComputedWeight(tt.args.targetPercentage, tt.args.totalCurrWeightOtherSvcs); got != tt.want {
+				t.Errorf("calcComputedWeight() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_calcIncrement(t *testing.T) {
+	type args struct {
+		duration                 time.Duration
+		targetPercentage         int
+		totalCurrWeight          int
+		totalCurrWeightOtherSvcs int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "no change should be 0",
+			args: args{
+				duration:                 time.Second * 1,
+				targetPercentage:         50,
+				totalCurrWeight:          100,
+				totalCurrWeightOtherSvcs: 50,
+			},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name: "basic large case",
+			args: args{
+				duration:                 time.Second * 60,
+				targetPercentage:         99,
+				totalCurrWeight:          1000,
+				totalCurrWeightOtherSvcs: 500,
+			},
+			want: 3267,
+		},
+		{
+			name: "basic small case",
+			args: args{
+				duration:                 time.Second * 60,
+				targetPercentage:         99,
+				totalCurrWeight:          100,
+				totalCurrWeightOtherSvcs: 50,
+			},
+			want: 327,
+		},
+		{
+			name: "basic scale down case in one step",
+			args: args{
+				duration:                 time.Second * 4,
+				targetPercentage:         50,
+				totalCurrWeight:          100,
+				totalCurrWeightOtherSvcs: 25,
+			},
+			want: 50,
+		},
+		{
+			name: "too low of an increment should error out",
+			args: args{
+				duration:                 time.Hour * 10,
+				targetPercentage:         50,
+				totalCurrWeight:          100,
+				totalCurrWeightOtherSvcs: 100,
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "dramatic scale down in one step",
+			args: args{
+				duration:                 time.Second * 1,
+				targetPercentage:         50,
+				totalCurrWeight:          100,
+				totalCurrWeightOtherSvcs: 1,
+			},
+			want: 98,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := calcIncrement(tt.args.duration, tt.args.targetPercentage, tt.args.totalCurrWeight, tt.args.totalCurrWeightOtherSvcs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("calcIncrement() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("calcIncrement() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalcWeightPercentage(t *testing.T) {
+	type args struct {
+		weight      int
+		totalWeight int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "basic case",
+			args: args{
+				weight:      775,
+				totalWeight: 1000,
+			},
+			want: 78,
+		},
+		{
+			name: "zero weight of 100 total",
+			args: args{
+				weight:      0,
+				totalWeight: 100,
+			},
+			want: 0,
+		},
+		{
+			name: "zero weight of zero total",
+			args: args{
+				weight:      0,
+				totalWeight: 0,
+			},
+			want: 0,
+		},
+		{
+			name: ".49% rounds down",
+			args: args{
+				weight:      1,
+				totalWeight: 201,
+			},
+			want: 0,
+		},
+		{
+			name: ".50% rounds up",
+			args: args{
+				weight:      1,
+				totalWeight: 200,
+			},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalcWeightPercentage(tt.args.weight, tt.args.totalWeight); got != tt.want {
+				t.Errorf("CalcWeightPercentage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -465,10 +465,10 @@ rio promote [OPTIONS] SERVICE_NAME
 
 ##### Options
 
-| flag       | aliases | description                                  | default |
-|------------|---------|----------------------------------------------|---------|
-| --duration | none    | How long the rollout should take             | 0s      |
-| --pause    | none    | Whether to pause all rollouts on current app | false   |
+| flag       | aliases | description                                                                   | default |
+|------------|---------|-------------------------------------------------------------------------------|---------|
+| --duration | none    | How long the rollout should take. An approximation, actual time may fluctuate | 0s      |
+| --pause    | none    | Whether to pause all rollouts on current app                                  | false   |
 
 ##### Examples
 
@@ -530,6 +530,7 @@ rio run [OPTIONS] IMAGE [COMMAND] [ARG...]
 ```
 
 ##### Options
+
 | flag                             | aliases  | description                                                                                   | default                |
 |----------------------------------|----------|-----------------------------------------------------------------------------------------------|------------------------|
 | --add-host value                 |          | Add a custom host-to-IP mapping (host=ip)                                                     |                        |
@@ -579,7 +580,7 @@ rio run [OPTIONS] IMAGE [COMMAND] [ARG...]
 | --ports value                    | -p value | Publish a container's port(s) (format: svcport:containerport/protocol)                        |                        |
 | --privileged                     |          | Run container with privilege                                                                  |                        |
 | --read-only                      |          | Mount the container's root filesystem as read only                                            |                        |
-| --rollout-duration value         |          | How long the rollout should take                                                              | "0s"                   |
+| --rollout-duration value         |          | How long the rollout should take. An approximation, actual time may fluctuate                 | "0s"                   |
 | --request-timeout-seconds value  |          | Set request timeout in seconds                                                                | 0                      |
 | --scale value                    |          | The number of replicas to run or a range for autoscaling (example 1-10)                       |                        |
 | --secret value                   |          | Secrets to inject to the service (format: name[/key]:target)                                  |                        |
@@ -789,10 +790,10 @@ rio weight [OPTIONS] SERVICE_NAME=PERCENTAGE
 
 ##### Options
 
-| flag       | aliases | description                                  | default |
-|------------|---------|----------------------------------------------|---------|
-| --duration |         | How long the rollout should take             | 0s      |
-| --pause    |         | Whether to pause all rollouts on current app | false   |
+| flag       | aliases | description                                                                   | default |
+|------------|---------|-------------------------------------------------------------------------------|---------|
+| --duration |         | How long the rollout should take. An approximation, actual time may fluctuate | 0s      |
+| --pause    |         | Whether to pause all rollouts on current app                                  | false   |
 
 ##### Examples
 

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ replace (
 )
 
 require (
-	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5
 	github.com/aokoli/goutils v1.1.0

--- a/modules/service/controllers/rollout/controller.go
+++ b/modules/service/controllers/rollout/controller.go
@@ -109,12 +109,11 @@ func (rh *rolloutHandler) rollout(key string, svc *riov1.Service) (*riov1.Servic
 			if abs(weightToAdjust) < s.Spec.RolloutConfig.Increment || (weightToAdjust > 0 && allOtherServicesOff(s, svcs)) { // adjust entire amount
 				computedWeight += weightToAdjust
 			} else { // only adjust one increment
-				oneIncrement := s.Spec.RolloutConfig.Increment
-				fluxedIncrement := incrementFlux(oneIncrement, *s.Spec.Weight, computedWeight)
+				oneIncrement := incrementFlux(s.Spec.RolloutConfig.Increment, *s.Spec.Weight, computedWeight)
 				if weightToAdjust < 0 {
-					fluxedIncrement = -fluxedIncrement
+					oneIncrement = -oneIncrement
 				}
-				computedWeight += fluxedIncrement
+				computedWeight += oneIncrement
 			}
 			*s.Status.ComputedWeight = computedWeight
 			rh.lastWrite[serviceKey(s)] = metav1.NewTime(time.Now())

--- a/modules/service/controllers/rollout/controller.go
+++ b/modules/service/controllers/rollout/controller.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const PromoteWeight = 10000
+
 type rolloutHandler struct {
 	services      riov1controller.ServiceController
 	serviceCache  riov1controller.ServiceCache
@@ -62,14 +64,14 @@ func (rh *rolloutHandler) rollout(key string, svc *riov1.Service) (*riov1.Servic
 	var updatedNeeded []string
 	if !computedWeightsExist(svcs) {
 		var added int
-		add := int(100.0 / float64(len(svcs)))
+		add := int(float64(PromoteWeight) / float64(len(svcs)))
 		for i, s := range svcs {
 			s.Status.ComputedWeight = new(int)
 			if i != len(svcs)-1 {
 				*s.Status.ComputedWeight = add
 				added += add
 			} else {
-				*s.Status.ComputedWeight = 100 - added
+				*s.Status.ComputedWeight = PromoteWeight - added
 			}
 			updatedNeeded = append(updatedNeeded, serviceKey(s))
 		}

--- a/modules/service/controllers/rollout/controller_test.go
+++ b/modules/service/controllers/rollout/controller_test.go
@@ -1,1 +1,69 @@
 package rollout
+
+import "testing"
+
+func Test_incrementFlux(t *testing.T) {
+	type args struct {
+		increment  int
+		goalWeight int
+		currWeight int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "10% curr weight should bring increment down by half",
+			args: args{
+				increment:  10,
+				goalWeight: 100,
+				currWeight: 0,
+			},
+			want: 5,
+		},
+		{
+			name: "50% curr weight should leave increment",
+			args: args{
+				increment:  10,
+				goalWeight: 100,
+				currWeight: 50,
+			},
+			want: 10,
+		},
+		{
+			name: "90% curr weight should increase increment by 1.25%",
+			args: args{
+				increment:  10,
+				goalWeight: 100,
+				currWeight: 90,
+			},
+			want: 12,
+		},
+		{
+			name: "Large change going down should still be multiplied by 1.25%",
+			args: args{
+				increment:  10,
+				goalWeight: 100,
+				currWeight: 1000,
+			},
+			want: 12,
+		},
+		{
+			name: "Small change going down should still be 50%",
+			args: args{
+				increment:  10,
+				goalWeight: 950,
+				currWeight: 1000,
+			},
+			want: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := incrementFlux(tt.args.increment, tt.args.goalWeight, tt.args.currWeight); got != tt.want {
+				t.Errorf("incrementFlux() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/test
+++ b/scripts/test
@@ -43,5 +43,6 @@ if [[ ${ARCH} == amd64 ]]; then
 
     trap print_log exit
 
-    go test -v ./tests/integration/... --integration-tests
+    echo 'Running integration tests...'
+    go test ./tests/integration/... --integration-tests
 fi


### PR DESCRIPTION
https://github.com/rancher/rio/issues/774
https://github.com/rancher/rio/issues/719

This PR does several things: 

* breaks out any tricky math into functions and unit tests them, including fixes and tests for edge cases
* fixes bug where run command wouldn't de-promote other services
* add magic so rollout is smoother
* fixed general bugs around rollout controller and weights
* updates rollout duration to 4 seconds from 2, to help avoid conflicts in api
* add note to cli and docs that rollout duration is estimation