### PR TITLE
Make router app vs version ux clearer

### DIFF
--- a/cli/cmd/route/route.go
+++ b/cli/cmd/route/route.go
@@ -11,7 +11,7 @@ func Route(app *cli.App) cli.Command {
 	create := builder.Command(&Create{},
 		"Create a router at the end",
 		app.Name+" router create/add MATCH ACTION [TARGET...]",
-		"To append a rule at the end, run `rio [-n $NAMESPACE] router add $ROUTE_NAME to|redirect|mirror|rewrite $SERVICE[@VERSION]")
+		"To append a rule at the end, run `rio [-n $NAMESPACE] router add $ROUTE_NAME to|redirect|mirror|rewrite $APP[@VERSION]. If version not specified app is assumed.")
 	create.Aliases = []string{"add"}
 	ls := builder.Command(&Ls{},
 		"List router",

--- a/cli/pkg/tables/router.go
+++ b/cli/pkg/tables/router.go
@@ -176,15 +176,17 @@ func writeHostPath(buf *strings.Builder, host, path string) {
 	}
 }
 
-func writeDest(buf *strings.Builder, service, revision string, port uint32, weight int) {
+func writeDest(buf *strings.Builder, service, version string, port uint32, weight int) {
 	if buf.Len() > 0 {
 		buf.WriteString(",")
 	}
 
 	buf.WriteString(service)
-	if revision != "" && revision != "latest" {
-		buf.WriteString(":")
-		buf.WriteString(revision)
+	if version != "" && version != "latest" {
+		buf.WriteString("@")
+		buf.WriteString(version)
+	} else {
+		buf.WriteString("(app)")
 	}
 
 	if port > 0 {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,6 +19,7 @@
 - [logs](#logs)
 - [promote](#promote)
 - [ps](#ps)
+- [router](#router)
 - [run](#run)
 - [rm](#rm)
 - [scale](#scale)
@@ -517,6 +518,75 @@ rio ps --format json
 # display name and weight in custom format
 rio ps --format "{{.Obj.Name}} -> {{.Data.Weight}}" 
 ```
+
+---
+
+## router
+
+Route traffic across the mesh
+
+##### Usage
+```
+rio routers command [command options] [arguments...]
+```
+
+##### Options
+
+| flag        | aliases | description                                                            | default |
+|-------------|---------|------------------------------------------------------------------------|---------|
+| --quiet     | -q      | Only display Names                                                     |         |
+| --format    |         | 'json' or 'yaml' or Custom format: '{{.Name}} {{.Obj.Name}}' [$FORMAT] |         |
+
+
+##### Examples
+
+```shell script
+# show existing routers
+rio route
+```
+
+#### add/create
+
+Create a router. By default appends at the end.
+
+Services specified without a version are assumed to be apps. For example `rio route add x to svc` would target the svc app endpoint,
+not the `svc@v0` version.
+
+##### Usage
+```
+rio router create/add MATCH ACTION [TARGET...]
+```
+
+##### Options
+
+| flag                              | aliases | description                                          | default |
+|-----------------------------------|---------|------------------------------------------------------|---------|
+| --insert                          |         | Insert the rule at the beginning instead of the end  |         |
+| --header value                    |         | Match HTTP header (format key=value, value optional) |         |
+| --fault-percentage value          |         | Percentage of matching requests to fault             | 0       |
+| --fault-delay-milli-seconds value |         | Inject a delay for fault in milliseconds             | 0       |
+| --fault-httpcode value            |         | HTTP code to send for fault injection                | 0       |
+| --add-header value                |         | Add HTTP header to request (format key=value)        |         |
+| --set-header value                |         | Override HTTP header to request (format key=value)   |         |
+| --remove-header value             |         | Remove HTTP header to request (format key=value)     |         |
+| --retry-attempts value            |         | How many times to retry                              | 0       |
+| --retry-timeout-seconds value     |         | Timeout per retry in seconds                         | 0       |
+| --timeout-seconds value           |         | Timeout in seconds for all requests                  | 0       |
+| --method value                    |         | Match HTTP method, support comma-separated values    |         |
+
+##### Examples
+
+```shell script
+
+# route to the demo app endpoint
+rio route add myroute to demo
+
+# route a specific path to the demo app's version 0, and insert into first slot
+rio route add --insert myroute/name.html to demo@v0
+```
+
+See the [routers readme](router.md) for advanced example usage.
+
 
 ---
 


### PR DESCRIPTION
Problem: if you do `rio ps` you get just `z` for `z@v0`, but if you do `rio route` then `z` means entire app not `z@v0`. What does everyone think of this solution ? 

<img width="669" alt="router" src="https://user-images.githubusercontent.com/571419/69376218-23340d00-0c67-11ea-9d7c-b490ae301791.png">

https://github.com/rancher/rio/issues/824
