### PR TITLE
Named riofiles shouldnt fallback to default riofile

### DIFF
--- a/docs/riofile.md
+++ b/docs/riofile.md
@@ -526,7 +526,7 @@ We can now access this endpoint over encrypted https!
 #### Using answer file 
 
 Rio allows the user to leverage an answer file to customize `Riofile`. 
-Go template and [envSubst](https://github.com/drone/envsubst) can used to apply answers. By default, the `NAMESPACE` variable is available.
+Go template and [envSubst](https://github.com/drone/envsubst) can used to apply answers. By default, the `NAMESPACE` variable is available when defined in the template questions.
 
 Answer file is a yaml manifest with key-value pairs:
 
@@ -538,8 +538,8 @@ For example, to use go templating to apply a service when provided with the abov
 
 1. Create Riofile
 ```yaml
+{{- if (and (eq .Values.NAMESPACE "test") (eq .Values.FOO "BAR")) }}
 services:
-{{- if eq .Values.FOO "BAR" and eq .Values.NAMESPACE "test" }}
   demo:
     image: ibuildthecloud/demo:v1
     ports:
@@ -551,10 +551,12 @@ template:
   envSubst: true # use ENV vars during templating  
   questions:  # now make some questions that we provide answers too
   - variable: FOO
-    description: ""
+    description: "My custom thing"
+  - variable: NAMESPACE
+    description: "The namespace"
 ```
 2. `kubectl create namespace test`
-3. `cd /path/to/Riofile && rio -n test up`
+3. `cd /path/to/Riofile && rio -n test up --answers answers.yaml`
 
 Rio also supports a bash style envsubst replacement, with the following format:
 

--- a/pkg/template/parse.go
+++ b/pkg/template/parse.go
@@ -104,6 +104,9 @@ func (t *Template) parseContent(answersCB AnswerCallback) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if template == nil {
+		return t.Content, nil
+	}
 
 	var (
 		callbackErrs []error


### PR DESCRIPTION
Issue: https://github.com/rancher/rio/issues/864

### Fixes
1. Doesn't fallback to `Riofile` when a named riofile fails
2. Doesn't unmarshall and error a named Riofile, as non-named Riofiles don't
3. Fixes panic
4. Fixes Readme


### Testing

Number 1. 
Have 2 Riofiles, one named Riofile and one named something else with different data that will fail to parse. Run `rio up -f named_file.yaml`. 

Number 2. 
Setup: save this as anything but `Riofile` and run up with `-f`, should fail to load, but it does load if named `Riofile`. Fix should allow either way. 
```
{{- if (and (eq .Values.NAMESPACE "test") (eq .Values.FOO "BAR")) }}
services:
  demo:
    image: ibuildthecloud/demo:v1
    ports:
    - 80
{{- end}}

template:
  goTemplate: true # use go templating
  envSubst: true # use ENV vars during templating  
  questions:  # now make some questions that we provide answers too
  - variable: FOO
    description: "My custom thing"
  - variable: NAMESPACE
    description: "The namespace"
```

Number 3. 

Name this Riofile and run just `rio up`
```
services:
{{- if eq .Values.FOO "BAR" and eq .Values.NAMESPACE "test" }}
  demo:
    image: ibuildthecloud/demo:v1
    ports:
    - 80
{{- end}}
```