### PR TITLE
Update uninstall to also remove RBAC objects

### DIFF
--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -97,6 +97,31 @@ func (u Uninstall) Run(ctx *clicontext.CLIContext) error {
 	if err := ctx.K8s.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(constants.AuthWebhookSecretName, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
+	clusterRoles, err := ctx.K8s.RbacV1beta1().ClusterRoles().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, clusterRole := range clusterRoles.Items {
+		if _, ok := clusterRole.Annotations["objectset.rio.cattle.io/owner-gvk"]; ok {
+			err = ctx.K8s.RbacV1beta1().ClusterRoles().Delete(clusterRole.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	clusterRoleBindings, err := ctx.K8s.RbacV1beta1().ClusterRoleBindings().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, clusterRoleBinding := range clusterRoleBindings.Items {
+		if _, ok := clusterRoleBinding.Annotations["objectset.rio.cattle.io/owner-gvk"]; ok {
+			err = ctx.K8s.RbacV1beta1().ClusterRoleBindings().Delete(clusterRoleBinding.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	fmt.Println("Rio is uninstalled from your cluster")
 	return nil

--- a/go.sum
+++ b/go.sum
@@ -868,8 +868,6 @@ github.com/rancher/norman v0.0.0-20191114233102-966e8db9e670 h1:EM5VxDfLyKFTEPVV
 github.com/rancher/norman v0.0.0-20191114233102-966e8db9e670/go.mod h1:zOBq0bQmo9slllyM1kcKpKr1RH5IWodjySaffLKSOx0=
 github.com/rancher/rdns-server v0.5.7-0.20190927164127-7128efe7d065 h1:K2/79Jdw0viw+ryWSJQcIMYJf2vc5yQXlEHPTbpVPVs=
 github.com/rancher/rdns-server v0.5.7-0.20190927164127-7128efe7d065/go.mod h1:/yw1tSnAWDSDSmhKpYNA/FBA49fbbtNfh/IHT31v7jE=
-github.com/rancher/stern v0.0.0-20191114200800-b31e21d4e493 h1:ebywCd5IyRRNzXgQWPsGW1xQbND9M88ZyjMS80M3a9U=
-github.com/rancher/stern v0.0.0-20191114200800-b31e21d4e493/go.mod h1:aaP5eLMmFcyJUsZB6FwAO+0eILWeBKvupuHeeEuY0qQ=
 github.com/rancher/stern v0.0.0-20191203174401-30397523f082 h1:rDHE/uQXR2tjyik9kkVI8SN3eSliuqbjouC427M8VUM=
 github.com/rancher/stern v0.0.0-20191203174401-30397523f082/go.mod h1:aaP5eLMmFcyJUsZB6FwAO+0eILWeBKvupuHeeEuY0qQ=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=


### PR DESCRIPTION
Update the cli uninstall to delete clusterRoles and
clusterRoleBindings by the annotation
"objectset.rio.cattle.io/owner-gvk"

Add a related resource watcher to cluster scoped RBAC roles and rolebindings to watch the Rio Service for changes. 