### PR TITLE
Automate cluster creation for k3s

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.13-alpine
 # Install all needed tools
 RUN apk update && \
   apk upgrade --update-cache --available && \
-  apk add build-base curl git
+  apk add build-base curl git jq openssh bash
 
 # Install the executables for kubectl, rio, and hey
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
@@ -19,12 +19,17 @@ RUN go mod download
 
 # Copy source code into working directory and make sure entrypoint is executable
 COPY . .
-RUN chmod +x ./tests/entrypoint.sh
+RUN chmod +x ./tests/scripts/*.sh
 
 # Set environment variables for tests to run properly and to ensure the correct rio version is being tested
+ENV CLUSTER local
 ENV KUBECONFIG /usr/local/projects/rio/.kube/config
 ENV test integration
 
 # Install Rio if needed and run tests
-ENTRYPOINT [ "./tests/entrypoint.sh" ]
-CMD go test -v ./tests/${test}/... -${test}-tests
+## NOTE: Need to pass in environment variables:
+ # CLUSTER   (optional - if wanting to build and use a new cluster. Valid options are 'k3s', 'rke', and 'gke')
+ # TOKEN     (required if CLUSTER is given as k3s or rke -- DigitalOcean API Token)
+ # WORKERS   (optional - if passing in the cluster option, you can specify how many additional worker nodes to add)
+ENTRYPOINT [ "./tests/scripts/entrypoint.sh" ]
+CMD ["./tests/scripts/test.sh"]

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-curl -sfL https://get.rio.io | sh - > /dev/null 2>&1
-
-# Install rio if it isn't already installed
-if ! [ "$(rio info | grep "Cluster Domain IPs")" ] ; then rio install ; fi
-
-exec "$@"

--- a/tests/scripts/cleanup_cluster.sh
+++ b/tests/scripts/cleanup_cluster.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Cleaning up resources from $CLUSTER cluster..."
+
+if [ "${CLUSTER}" == "k3s" ]; then
+  # Delete droplets
+  for ((i=0; i<=$NUM_WORKERS; i++))
+  do
+    curl -s -X DELETE -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" "https://api.digitalocean.com/v2/droplets/$(eval echo \${NODEID_$i})"
+  done
+  # Delete ssh key
+  curl -s -X DELETE -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" "https://api.digitalocean.com/v2/account/keys/$(echo $SSH_KEY | jq -r .ssh_key.id)"
+elif [ "${CLUSTER}" == "gke" ]; then
+  echo "cleanup gke..."
+elif [ "${CLUSTER}" == "rke" ]; then
+  echo "cleanup rke..."
+fi
+
+echo "$CLUSTER cluster resources deleted."

--- a/tests/scripts/entrypoint.sh
+++ b/tests/scripts/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ "${CLUSTER}" == "k3s" ]; then
+  source ./tests/scripts/install_k3s.sh
+elif [ "${CLUSTER}" == "gke" ]; then
+  source ./tests/scripts/install_gke.sh
+elif [ "${CLUSTER}" == "rke" ]; then
+  source ./tests/scripts/install_rke.sh
+else
+  echo "Using given cluster with given kubeconfig..."
+fi
+
+# Get rio binary
+curl -sfL https://get.rio.io | sh - > /dev/null 2>&1
+
+# Install rio if it isn't already installed
+if ! [ "$(rio info | grep "Cluster Domain IPs")" ] ; then rio install ; fi
+
+if [ "${CLUSTER}" == "k3s" ]; then kubectl delete svc traefik -n kube-system ; fi
+
+exec "$@"

--- a/tests/scripts/install_gke.sh
+++ b/tests/scripts/install_gke.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Configuring GKE cluster..."

--- a/tests/scripts/install_k3s.sh
+++ b/tests/scripts/install_k3s.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+echo "Configuring k3s cluster on Digital Ocean..."
+
+# Create new ssh-key
+create_ssh_key() {
+  SSH_KEY_NAME="rio-test-"$(cat /dev/random | LC_CTYPE=C tr -dc "[:alnum:]" | head -c 5)
+  ssh-keygen -t rsa -N "" -f $SSH_KEY_NAME.key -q
+  SSH_KEY=$(curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d"{\"name\":\"$SSH_KEY_NAME\",\"public_key\":\"$(cat $SSH_KEY_NAME.key.pub)\"}" "https://api.digitalocean.com/v2/account/keys")
+  export SSH_KEY
+}
+
+create_nodes() {
+  # Create nodes in Digital Ocean
+  DO_RESULT_NODES=()
+  for ((i=0; i<=$1; i++))
+  do
+    DO_RESULT_NODES[$i]=$(curl -s -X POST "https://api.digitalocean.com/v2/droplets" -d"{\"names\":[\"rio-automated-k3s-node-$((i + 1))\"],\"region\":\"sfo2\",\"size\":\"s-2vcpu-4gb\",\"image\":\"ubuntu-18-04-x64\",\"ssh_keys\":[$(echo $SSH_KEY | jq -r .ssh_key.id)]}" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json")
+  done
+
+  # Wait until nodes statuses are active
+  for ((i=0; i<=$1; i++))
+  do
+    DO_RESULT_NODES[$i]=$(curl -s -X GET -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" "https://api.digitalocean.com/v2/droplets/$(echo ${DO_RESULT_NODES[$i]} | jq .droplets[0].id)")
+    until [ $(echo ${DO_RESULT_NODES[$i]} | jq -r .droplet.status) == "active" ]
+    do
+      sleep 5
+      DO_RESULT_NODES[$i]=$(curl -s -X GET -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" "https://api.digitalocean.com/v2/droplets/$(echo ${DO_RESULT_NODES[$i]} | jq .droplet.id)")
+    done
+  done
+
+  for ((i=0; i<=$1; i++))
+  do
+    export NODEID_$i=$(echo ${DO_RESULT_NODES[$i]} | jq .droplet.id)
+  done
+  sleep 30
+}
+
+install_k3s_on_master() {
+  ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_NAME.key root@$(echo ${DO_RESULT_NODES[0]} | jq -r .droplet.networks.v4[0].ip_address) /bin/bash <<- EOF
+    curl -sfL https://get.k3s.io | sh -
+EOF
+}
+
+add_k3s_agents() {
+  for ((i=1; i<=$1; i++))
+  do
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_NAME.key root@$(echo ${DO_RESULT_NODES[$i]} | jq -r .droplet.networks.v4[0].ip_address) /bin/bash <<- EOF
+      curl -sfL https://get.k3s.io | K3S_URL=https://$(echo ${DO_RESULT_NODES[$i]} | jq -r .droplet.networks.v4[0].ip_address):6443 K3S_TOKEN="$(echo $NODE_TOKEN)" sh -
+EOF
+  done
+}
+
+export NUM_WORKERS=${WORKERS-2}
+create_ssh_key
+create_nodes NUM_WORKERS
+install_k3s_on_master
+
+# Extract NODE_TOKEN and KUBECONFIG from master node
+NODE_TOKEN=$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_NAME.key root@$(echo ${DO_RESULT_NODES[0]} | jq -r .droplet.networks.v4[0].ip_address) "cat /var/lib/rancher/k3s/server/node-token")
+LOCAL_CONFIG=$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_NAME.key root@$(echo ${DO_RESULT_NODES[0]} | jq -r .droplet.networks.v4[0].ip_address) "kubectl config view --flatten -o json")
+echo "${LOCAL_CONFIG//127.0.0.1/$(echo ${DO_RESULT_NODES[0]} | jq -r .droplet.networks.v4[0].ip_address)}" > .kube/config
+
+add_k3s_agents NUM_WORKERS
+echo "k3s cluster successfully configured with $((NUM_WORKERS + 1)) nodes."

--- a/tests/scripts/install_rke.sh
+++ b/tests/scripts/install_rke.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Configuring RKE cluster on Digital Ocean..."

--- a/tests/scripts/test.sh
+++ b/tests/scripts/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "${test}" == "all" ]; then
+  go test -v ./tests/integration/... -integration-tests
+  go test -v ./tests/validation/... -validation-tests
+elif [ "${test}" == "integration" ] || [ "${test}" == "validation" ]; then
+  go test -v ./tests/${test}/... -${test}-tests
+else
+  echo "Only acceptable values for environment variable 'test' are 'integration', 'validation', and 'all'."
+fi
+
+source ./tests/scripts/cleanup_cluster.sh

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -266,11 +266,13 @@ func CreateCNAME(clusterDomain string) *route53.ChangeResourceRecordSetsOutput {
 	if err != nil {
 		fmt.Println("failed to create session make sure to add credentials to ~/.aws/credentials,", err)
 		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 	cname := GetCNAMEInfo()
 	zoneID := getZoneIDInfo()
 	if cname == "" || clusterDomain == "" || zoneID == "" {
 		fmt.Println(fmt.Errorf("incomplete information: d: %s, t: %s, z: %s", cname, clusterDomain, zoneID))
+		os.Exit(1)
 	}
 	svc := route53.New(sess)
 
@@ -299,6 +301,7 @@ func CreateCNAME(clusterDomain string) *route53.ChangeResourceRecordSetsOutput {
 
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 	return resp
 }


### PR DESCRIPTION
This allows going from nothing to running all rio tests on demand in a k3s cluster. Later it will be expanded for GKE and RKE clusters as well:

The first step is always to build the image: `docker build -f ./tests/Dockerfile -t rio-test .`
Then there are a few options:
- `docker run --rm -e CLUSTER=k3s -e TOKEN=<your Digital Ocean token> -e WORKERS=1 rio-test:latest`

- `docker run --rm -e test=all -e CLUSTER=k3s -e TOKEN=<your Digital Ocean token> -e AWS_ACCESS_KEY_ID=<aws access key> -e AWS_SECRET_ACCESS_KEY=<aws secret key> -e RIO_ROUTE53_ZONEID=<aws route53 zone id> -e RIO_ROUTE53_ZONENAME=<aws route53 zone name> rio-test:latest`

- Copy a kubeconfig file to /path/to/rio/.kube/config and then `docker run --rm -e test=integration rio-test:latest`