### PR TITLE
Fix clusterdomain for ingress, start build and add systemconfig in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rio is currently in Beta.
 Connect with us on the #rio channel on the [rancher slack](https://slack.rancher.io/)
 
 ## Documentation
-See the [docs folder](/docs/README.md) for detailed documentation and guides.
+See the [docs folder](https://github.com/rancher/rio/tree/v0.6.0/docs) for detailed documentation and guides.
 
 ## Quick Start
 

--- a/cli/cmd/buildhistory/buildhistory.go
+++ b/cli/cmd/buildhistory/buildhistory.go
@@ -1,11 +1,13 @@
 package buildhistory
 
 import (
+	"github.com/rancher/rio/cli/pkg/build"
 	"github.com/rancher/rio/cli/pkg/builder"
 	"github.com/rancher/rio/cli/pkg/clicontext"
 	"github.com/rancher/rio/cli/pkg/table"
 	"github.com/rancher/rio/cli/pkg/tables"
 	"github.com/rancher/rio/cli/pkg/types"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -30,6 +32,10 @@ func (b *BuildHistory) Customize(cmd *cli.Command) {
 }
 
 func (b BuildHistory) Run(ctx *clicontext.CLIContext) error {
+	if err := build.EnableBuildAndWait(ctx); err != nil {
+		logrus.Warn(err)
+	}
+
 	objs, err := ctx.List(types.BuildType)
 	if err != nil {
 		return err

--- a/cli/cmd/builds/build.go
+++ b/cli/cmd/builds/build.go
@@ -5,11 +5,13 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/rancher/rio/cli/pkg/build"
 	"github.com/rancher/rio/cli/pkg/builder"
 	"github.com/rancher/rio/cli/pkg/clicontext"
 	"github.com/rancher/rio/cli/pkg/up"
 	riov1 "github.com/rancher/rio/pkg/apis/rio.cattle.io/v1"
 	"github.com/rancher/rio/pkg/stack"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"sigs.k8s.io/yaml"
 )
@@ -30,6 +32,10 @@ type Build struct {
 }
 
 func (b *Build) Run(ctx *clicontext.CLIContext) error {
+	if err := build.EnableBuildAndWait(ctx); err != nil {
+		logrus.Warn(err)
+	}
+
 	content, err := up.LoadRiofile(b.F_File)
 	if err != nil {
 		return err

--- a/cli/cmd/pods/pods.go
+++ b/cli/cmd/pods/pods.go
@@ -9,9 +9,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-type Pod struct {
-	C_Containers bool `desc:"print containers, not services"`
-}
+type Pod struct{}
 
 func (p *Pod) Customize(cmd *cli.Command) {
 	cmd.Flags = append(table.WriterFlags(), cmd.Flags...)

--- a/cli/cmd/systemconfig/viewconfig.go
+++ b/cli/cmd/systemconfig/viewconfig.go
@@ -1,0 +1,59 @@
+package systemconfig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rancher/rio/cli/cmd/edit/edit"
+	"github.com/rancher/rio/cli/pkg/clicontext"
+	"github.com/rancher/rio/pkg/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SystemConfig struct {
+	Edit bool `desc:"edit system configuration"`
+}
+
+func (s *SystemConfig) Run(ctx *clicontext.CLIContext) error {
+	cm, err := ctx.Core.ConfigMaps(ctx.SystemNamespace).Get(config.ConfigName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	conf, err := config.FromConfigMap(cm)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(conf, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if s.Edit {
+		update, err := edit.Loop(nil, data, func(modifiedContent []byte) error {
+			if err := json.Unmarshal(modifiedContent, &conf); err != nil {
+				return err
+			}
+			cm, err = config.SetConfig(cm, conf)
+			if err != nil {
+				return err
+			}
+			if _, err := ctx.Core.ConfigMaps(ctx.SystemNamespace).Update(cm); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		if !update {
+			fmt.Println("No change to system config")
+		}
+		return nil
+	}
+
+	fmt.Println(string(data))
+	return nil
+}

--- a/cli/cmd/up/up.go
+++ b/cli/cmd/up/up.go
@@ -3,12 +3,14 @@ package up
 import (
 	"fmt"
 
+	"github.com/rancher/rio/cli/pkg/build"
 	"github.com/rancher/rio/cli/pkg/clicontext"
 	"github.com/rancher/rio/cli/pkg/up"
 	riov1 "github.com/rancher/rio/pkg/apis/rio.cattle.io/v1"
 	"github.com/rancher/rio/pkg/riofile/stringers"
 	"github.com/rancher/rio/pkg/stack"
 	"github.com/rancher/wrangler/pkg/gvk"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,6 +61,10 @@ func (u *Up) Run(c *clicontext.CLIContext) error {
 
 func (u *Up) setStack(c *clicontext.CLIContext, existing *riov1.Stack) error {
 	if len(c.CLI.Args()) == 1 {
+		if err := build.EnableBuildAndWait(c); err != nil {
+			logrus.Warn(err)
+		}
+
 		var err error
 		if existing.Spec.Build == nil {
 			existing.Spec.Build = &riov1.StackBuild{}

--- a/cli/main.go
+++ b/cli/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rancher/rio/cli/cmd/secrets"
 	"github.com/rancher/rio/cli/cmd/stacks"
 	"github.com/rancher/rio/cli/cmd/stage"
+	"github.com/rancher/rio/cli/cmd/systemconfig"
 	"github.com/rancher/rio/cli/cmd/systemlogs"
 	"github.com/rancher/rio/cli/cmd/uninstall"
 	"github.com/rancher/rio/cli/cmd/up"
@@ -218,6 +219,11 @@ func main() {
 		builder.Command(&systemlogs.SystemLogs{},
 			"View system log for Rio management plane",
 			appName+" systemlogs",
+			""),
+
+		builder.Command(&systemconfig.SystemConfig{},
+			"View/Edit system configuration",
+			appName+" systemconfig",
 			""),
 
 		builder.Command(&uninstall.Uninstall{},

--- a/cli/pkg/build/build.go
+++ b/cli/pkg/build/build.go
@@ -1,0 +1,55 @@
+package build
+
+import (
+	"github.com/rancher/rio/cli/pkg/clicontext"
+	"github.com/rancher/rio/cli/pkg/deploymentstatus"
+	"github.com/rancher/rio/cli/pkg/progress"
+	"github.com/rancher/rio/pkg/config"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func EnableBuildAndWait(ctx *clicontext.CLIContext) error {
+	cm, err := ctx.Core.ConfigMaps(ctx.SystemNamespace).Get(config.ConfigName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	conf, err := config.FromConfigMap(cm)
+	if err != nil {
+		return err
+	}
+
+	if conf.Features == nil {
+		conf.Features = map[string]config.FeatureConfig{}
+	}
+
+	t := true
+	f := conf.Features["build"]
+	f.Enabled = &t
+	conf.Features["build"] = f
+
+	cm, err = config.SetConfig(cm, conf)
+	if err != nil {
+		return err
+	}
+	if _, err := ctx.Core.ConfigMaps(ctx.SystemNamespace).Update(cm); err != nil {
+		return err
+	}
+
+	writer := progress.NewWriter()
+	for {
+		deployment, err := ctx.Apps.Deployments(ctx.SystemNamespace).Get("buildkitd", metav1.GetOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		if deployment == nil || !deploymentstatus.IsReady(deployment.Status) {
+			writer.Display("Waiting for buildkitd to start", 2)
+			continue
+		}
+		break
+	}
+
+	return nil
+}

--- a/cli/pkg/clicontext/config.go
+++ b/cli/pkg/clicontext/config.go
@@ -64,10 +64,6 @@ func (c *Config) Validate() error {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	if c.ShowSystemNamespace {
-		c.DefaultNamespace = c.SystemNamespace
-	}
-
 	loader := kubeconfig.GetInteractiveClientConfig(c.Kubeconfig)
 
 	defaultNs, _, err := loader.Namespace()
@@ -136,6 +132,10 @@ func (c *Config) Validate() error {
 
 	if info, err := project.RioInfos().Get("rio", metav1.GetOptions{}); err == nil {
 		c.SystemNamespace = info.Status.SystemNamespace
+	}
+
+	if c.ShowSystemNamespace {
+		c.DefaultNamespace = c.SystemNamespace
 	}
 
 	c.Writer = os.Stdout

--- a/cli/pkg/deploymentstatus/status.go
+++ b/cli/pkg/deploymentstatus/status.go
@@ -1,0 +1,15 @@
+package deploymentstatus
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func IsReady(status appsv1.DeploymentStatus) bool {
+	for _, con := range status.Conditions {
+		if con.Type == appsv1.DeploymentAvailable && con.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/pkg/up/build.go
+++ b/cli/pkg/up/build.go
@@ -10,11 +10,13 @@ import (
 	"strings"
 
 	"github.com/rancher/rio/cli/cmd/apply"
+	"github.com/rancher/rio/cli/pkg/build"
 	"github.com/rancher/rio/cli/pkg/clicontext"
 	"github.com/rancher/rio/cli/pkg/localbuilder"
 	riov1 "github.com/rancher/rio/pkg/apis/rio.cattle.io/v1"
 	"github.com/rancher/rio/pkg/constants"
 	"github.com/rancher/rio/pkg/stack"
+	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
 
@@ -41,6 +43,11 @@ func Build(builds map[stack.ContainerBuildKey]riov1.ImageBuildSpec, c *clicontex
 	if len(builds) == 0 {
 		return nil, nil
 	}
+
+	if err := build.EnableBuildAndWait(c); err != nil {
+		logrus.Warn(err)
+	}
+
 	localBuilder, err := localbuilder.NewLocalBuilder(c.Ctx, c.SystemNamespace, c.Apply, c.K8s)
 	if err != nil {
 		return nil, err

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,6 +25,7 @@
 - [scale](#scale)
 - [stage](#stage)
 - [systemlogs](#systemlogs)
+- [systemconfig](#systemconfig)
 - [uninstall](#uninstall)
 - [up](#up)
 - [weight](#weight)
@@ -772,6 +773,21 @@ Print the logs from the Rio management plane
 ##### Usage
 ```
 rio systemlogs
+```
+
+---
+
+## systemconfig
+
+View/Edit system configuration
+
+##### Uasge
+```bash
+# view system config
+rio systemconfig
+
+# edit system config
+rio systemconfig --edit
 ```
 
 ---

--- a/modules/rdns/controllers/service/handler.go
+++ b/modules/rdns/controllers/service/handler.go
@@ -220,6 +220,8 @@ func (h *handler) generateFromIngress(ingress *v1beta1.Ingress, status v1beta1.I
 		},
 		Spec: adminv1.ClusterDomainSpec{
 			Addresses: addresses,
+			HTTPSPort: 443,
+			HTTPPort:  80,
 		},
 	}
 


### PR DESCRIPTION
This commit fix bugs that clusterdomain's httpPort and httpsPort is not
being set, and start build feature on demand when user calls build
related CLI. Also add systemconfig in CLI to better view/edit feature
config.