### PR TITLE
Fix build, domain, and validation tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.13-alpine
 # Install all needed tools
 RUN apk update && \
   apk upgrade --update-cache --available && \
-  apk add build-base curl git jq openssh bash
+  apk add build-base curl git jq openssh bash docker
 
 # Install the executables for kubectl, rio, and hey
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
@@ -19,7 +19,7 @@ RUN go mod download
 
 # Copy source code into working directory and make sure entrypoint is executable
 COPY . .
-RUN chmod +x ./tests/scripts/*.sh
+RUN chmod +x ./tests/scripts/*.sh && chmod +x ./scripts/build
 
 # Set environment variables for tests to run properly and to ensure the correct rio version is being tested
 ENV CLUSTER local
@@ -28,8 +28,11 @@ ENV test integration
 
 # Install Rio if needed and run tests
 ## NOTE: Need to pass in environment variables:
- # CLUSTER   (optional - if wanting to build and use a new cluster. Valid options are 'k3s', 'rke', and 'gke')
- # TOKEN     (required if CLUSTER is given as k3s or rke -- DigitalOcean API Token)
- # WORKERS   (optional - if passing in the cluster option, you can specify how many additional worker nodes to add)
+ # RIO_VERSION  (optional - pass 'master' if wanting to build from source)
+ # REPO         (required if RIO_VERSION=master. Specify docker username for rio_controller)
+ # TAG          (required if RIO_VERSION=master. Specify rio_controller tag. Ends up like: ${REPO}/rio-controller:${TAG})
+ # CLUSTER      (optional - if wanting to build and use a new cluster. Valid options are 'k3s', 'rke', and 'gke')
+ # TOKEN        (required if CLUSTER is given as k3s or rke -- DigitalOcean API Token)
+ # WORKERS      (optional - if passing in the cluster option, you can specify how many additional worker nodes to add)
 ENTRYPOINT [ "./tests/scripts/entrypoint.sh" ]
 CMD ["./tests/scripts/test.sh"]

--- a/tests/integration/build_test.go
+++ b/tests/integration/build_test.go
@@ -30,9 +30,7 @@ func buildTests(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, "hello world: v1", service.GetEndpointResponse())
 			assert.Equal(t, 1, stagedService.GetAvailableReplicas(), "should have one available replica")
 			assert.Equal(t, "hello world: v2", stagedService.GetEndpointResponse())
-			assert.Equal(t, "hello world: v1", stagedService.GetAppEndpointResponse())
-			stagedService.Promote()
-			assert.Equal(t, "hello world: v2", stagedService.GetAppEndpointResponse())
+			assert.Equal(t, testutil.GetHostname(service.GetAppEndpointURLs()[0]), testutil.GetHostname(stagedService.GetAppEndpointURLs()[0]))
 		})
 	}, spec.Parallel())
 }

--- a/tests/integration/domain_test.go
+++ b/tests/integration/domain_test.go
@@ -28,8 +28,9 @@ func domainTests(t *testing.T, when spec.G, it spec.S) {
 			domain.RegisterDomain(t, randomDomain, service.Name)
 			assert.Equal(t, randomDomain, domain.GetDomain())
 			assert.Equal(t, randomDomain, domain.GetKubeDomain())
-			appEndpoints := service.GetAppEndpointURLs()
-			assert.Contains(t, appEndpoints, "http://"+randomDomain)
+			assert.Equal(t, domain.GetTargetApp(), service.Name)
+			assert.Nil(t, service.WaitForDomain(randomDomain))
+			assert.Contains(t, service.GetAppEndpointURLs(), "http://"+randomDomain)
 		})
 	}, spec.Parallel())
 }

--- a/tests/scripts/entrypoint.sh
+++ b/tests/scripts/entrypoint.sh
@@ -11,11 +11,21 @@ else
 fi
 
 # Get rio binary
-curl -sfL https://get.rio.io | sh - > /dev/null 2>&1
+if [ "${RIO_VERSION}" == "master" ]; then
+  echo "Installing rio from source"
+  ./scripts/build && docker build -f package/Dockerfile -t ${REPO}/rio-controller:${TAG} -q --force-rm .
+  go build -ldflags " -X github.com/rancher/rio/pkg/constants.ControllerImage=${REPO}/rio-controller -X github.com/rancher/rio/pkg/constants.ControllerImageTag=${TAG}" -i -o bin/rio cli/main.go
+  cp ./bin/rio /usr/local/bin/
+else
+  curl -sfL https://get.rio.io | sh - > /dev/null 2>&1
+fi
 
 # Install rio if it isn't already installed
-if ! [ "$(rio info | grep "Cluster Domain IPs")" ] ; then rio install ; fi
+if ! [ "$(rio info | grep "Cluster Domain IPs")" ] ; then rio install --no-email ; fi
 
 if [ "${CLUSTER}" == "k3s" ]; then kubectl delete svc traefik -n kube-system ; fi
+
+rio info
+rio build-history
 
 exec "$@"

--- a/tests/testutil/publicdomain.go
+++ b/tests/testutil/publicdomain.go
@@ -48,6 +48,15 @@ func (td *TestDomain) UnRegister() {
 }
 
 // GetDomain returns standard format non-namespaced domain, ex: "foo.bar"
+func (td *TestDomain) GetTargetApp() string {
+	err := td.reload()
+	if err != nil {
+		td.T.Fatalf("failed to fetch domain: %v", err.Error())
+	}
+	return td.PublicDomain.Spec.TargetApp
+}
+
+// GetDomain returns standard format non-namespaced domain, ex: "foo.bar"
 func (td *TestDomain) GetDomain() string {
 	err := td.reload()
 	if err != nil {
@@ -94,6 +103,7 @@ func (td *TestDomain) waitForDomain() error {
 		err := td.reload()
 		if err == nil {
 			if td.PublicDomain.Spec.TargetApp != "" {
+				time.Sleep(2 * time.Second) // sleep 2 seconds here to ensure the app endpoint is available as well
 				return true, nil
 			}
 		}

--- a/tests/validation/autoscale_test.go
+++ b/tests/validation/autoscale_test.go
@@ -25,7 +25,7 @@ func autoscaleTests(t *testing.T, when spec.G, it spec.S) {
 		it("should autoscale down to 0", func() {
 			// Precondition
 			assert.True(t, service.IsReady())
-			assert.Equal(t, "Hello World", service.GetAppEndpointResponse())
+			assert.Equal(t, "Hi there, I am rio:production6", service.GetAppEndpointResponse())
 
 			// When no requests happen for a while, it should scale to 0
 			service.WaitForScaleDown()

--- a/tests/validation/weight_test.go
+++ b/tests/validation/weight_test.go
@@ -26,15 +26,17 @@ func weightTests(t *testing.T, when spec.G, it spec.S) {
 			stagedService.Remove()
 		})
 		it("should slowly increase weight on the staged service and leave service weight unchanged", func() {
-			assert.Equal(t, 100, service.GetComputedWeight())
-			// The time from rollout to obtaining the current weight, without Sleep, is 2 seconds.
-			// Sleeping 9 seconds to guarantee 5 rollout ticks with 1 second to spare since the default tick interval is 2 seconds.
+			assert.Equal(t, 10000, service.GetComputedWeight())
+			// The time from starting rollout to obtaining the current weight, without Sleep, is 1 to 2 seconds due to program execution time.
+			// Sleeping 5 seconds to guarantee 2 rollout ticks with 1 to 2 seconds to spare since the default tick interval is 4 seconds.
 			stagedService.WeightWithoutWaiting(60, "--duration=1m")
-			time.Sleep(8 * time.Second)
+			time.Sleep(5 * time.Second)
 			stagedComputedWeightAfter10Seconds, serviceComputedWeightAfter10Seconds := stagedService.GetComputedWeight(), service.GetComputedWeight()
-			assert.Less(t, 10, stagedComputedWeightAfter10Seconds)
-			assert.Greater(t, 30, stagedComputedWeightAfter10Seconds)
-			assert.Equal(t, 100, serviceComputedWeightAfter10Seconds)
+			// Wide range given here because the weight change amount is about 500 to 600, so it can be as high as 1601 and as low as 500 in this scenario.
+			// Usually the weight will be 1033
+			assert.Less(t, 499, stagedComputedWeightAfter10Seconds)
+			assert.Greater(t, 1602, stagedComputedWeightAfter10Seconds)
+			assert.Equal(t, 10000, serviceComputedWeightAfter10Seconds)
 		})
 	}, spec.Parallel())
 }


### PR DESCRIPTION
This also enables building rio from master. So running the following will run all integration and validation tests in a fresh cluster:
```bash
$ docker build -f ./tests/Dockerfile -t rio-test .
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e test=all -e RIO_VERSION=master -e REPO=${DOCKER_USERNAME} -e TAG=dev -e CLUSTER=k3s -e TOKEN=${DigitalOcean_Token} -e WORKERS=2 -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_KEY} -e RIO_ROUTE53_ZONEID=${ROUTE53_ZONEID} -e RIO_ROUTE53_ZONENAME=${ROUTE53_ZONENAME} rio-test:latest
```