### PR TITLE
Fix 503 & 'no healthy upstream' issues

### DIFF
--- a/modules/gloo/pkg/vsfactory/app.go
+++ b/modules/gloo/pkg/vsfactory/app.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (f *VirtualServiceFactory) ForApp(namespace, appName string, svcs []*riov1.Service) ([]*solov1.VirtualService, error) {
-	hostnames, targets, err := getTargetsForApp(svcs, f.systemNamespace)
+	hostnames, targets, err := f.getTargetsForApp(svcs, f.systemNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/gloo/pkg/vsfactory/revision.go
+++ b/modules/gloo/pkg/vsfactory/revision.go
@@ -12,7 +12,7 @@ import (
 func (f *VirtualServiceFactory) ForRevision(svc *riov1.Service) ([]*solov1.VirtualService, error) {
 	app, version := services.AppAndVersion(svc)
 
-	target, err := getTarget(svc, f.systemNamespace)
+	target, err := f.getTarget(svc, f.systemNamespace)
 	if err != nil || !target.valid() {
 		return nil, err
 	}

--- a/modules/gloo/pkg/vsfactory/target.go
+++ b/modules/gloo/pkg/vsfactory/target.go
@@ -14,9 +14,12 @@ import (
 	"github.com/rancher/rio/pkg/serviceports"
 	"github.com/rancher/rio/pkg/services"
 	"github.com/rancher/wrangler/pkg/name"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
+// the target struct is used to hold information for networking decisions
 type target struct {
 	Hosts          []string
 	Port           int32
@@ -34,7 +37,8 @@ func (t target) valid() bool {
 	return t.Port != 0 && len(t.Hosts) > 0
 }
 
-func getTarget(obj *riov1.Service, systemNamespace string) (result target, err error) {
+// getTarget returns 1 target for a specified rio service
+func (f *VirtualServiceFactory) getTarget(obj *riov1.Service, systemNamespace string) (result target, err error) {
 	app, version := services.AppAndVersion(obj)
 	result.Name = name.SafeConcatName(app, version)
 	result.Namespace = obj.Namespace
@@ -51,32 +55,31 @@ func getTarget(obj *riov1.Service, systemNamespace string) (result target, err e
 		}
 	}
 
-	if obj.Status.ComputedReplicas != nil && *obj.Status.ComputedReplicas == 0 {
-		result.ScaleIsZero = true
-		result.Port = 80
-		result.OriginalTarget = struct {
-			Name      string
-			Namespace string
-		}{Name: obj.Name, Namespace: result.Namespace}
-		result.Name = constants.AutoscalerServiceName
-		result.Namespace = systemNamespace
+	result.Hosts, err = determineHosts(obj.Status.Endpoints)
+	if err != nil {
+		return result, err
 	}
 
-	seen := map[string]bool{}
-	for _, endpoint := range obj.Status.Endpoints {
-		u, err := url.Parse(endpoint)
+	if obj.Status.ComputedReplicas != nil { // valid candidate for a service that can be scaled to zero
+		result.ScaleIsZero, err = f.isScaleZero(app, version, result.Namespace)
 		if err != nil {
 			return result, err
 		}
-		if seen[u.Host] {
-			continue
+		if result.ScaleIsZero {
+			if *obj.Status.ComputedReplicas > 0 {
+				logrus.Debug("service has ComputedReplicas > 0 but no IP address allocated via k8s endpoints yet")
+			}
+			result.Port = 80
+			result.OriginalTarget = struct {
+				Name      string
+				Namespace string
+			}{Name: obj.Name, Namespace: result.Namespace}
+			result.Name = constants.AutoscalerServiceName
+			result.Namespace = systemNamespace
 		}
-		seen[u.Host] = true
 
-		result.Hosts = append(result.Hosts, u.Host)
 	}
 
-	sort.Strings(result.Hosts)
 	return
 }
 
@@ -126,7 +129,7 @@ func (f *VirtualServiceFactory) FindTLS(namespace, app, version string, hostname
 	return result, nil
 }
 
-func getTargetsForApp(svcs []*riov1.Service, systemNamespace string) (hostnames []string, targets []target, err error) {
+func (f *VirtualServiceFactory) getTargetsForApp(svcs []*riov1.Service, systemNamespace string) (hostnames []string, targets []target, err error) {
 	var (
 		seen = map[string]bool{}
 	)
@@ -136,7 +139,7 @@ func getTargetsForApp(svcs []*riov1.Service, systemNamespace string) (hostnames 
 		if svc.Spec.Template {
 			continue
 		}
-		target, err := getTarget(svc, systemNamespace)
+		target, err := f.getTarget(svc, systemNamespace)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -175,4 +178,58 @@ func formatHost(port, defaultPort int, hostname string) string {
 		return hostname
 	}
 	return fmt.Sprintf("%s:%d", hostname, port)
+}
+
+// check if a candidate service is scale zero, does not check if the service CAN be scaled from zero
+// returns true if there are NO k8s endpoints for the service allocated yet
+func (f *VirtualServiceFactory) isScaleZero(appName, version, namespace string) (bool, error) {
+	// for services scaled to zero, ensure endpoint has an IP address
+	req, err := labels.NewRequirement("app", selection.Equals, []string{appName})
+	if err != nil {
+		return false, err
+	}
+	reqVer, err := labels.NewRequirement("version", selection.Equals, []string{version})
+	if err != nil {
+		return false, err
+	}
+	selector := labels.NewSelector().Add(*req)
+	selector = selector.Add(*reqVer)
+	// use a selector for the app + version endpoint (ie RioApp-v0) versus app endpoint to see if service is up
+	k8sEndpoints, err := f.endpoints.List(namespace, selector)
+	if err != nil {
+		return false, err
+	}
+	if len(k8sEndpoints) == 0 {
+		logrus.Debugf("no corev1.Endpoints found for %s with version %s", appName, version)
+		return false, nil
+	}
+	// check all k8s endpoints to see if any IP addresses exist
+	for _, endpoint := range k8sEndpoints {
+		if len(endpoint.Subsets) != 0 {
+			// ip address allocated for this service, should not be scale zero
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// determineHosts returns a set of hosts based upon the rio services endpoint URLs
+func determineHosts(hostNameEndpoints []string) ([]string, error) {
+	seen := map[string]bool{}
+	hostSet := make([]string, 0, len(hostNameEndpoints))
+	for _, endpoint := range hostNameEndpoints {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			return []string{}, err
+		}
+		if seen[u.Host] {
+			continue
+		}
+		seen[u.Host] = true
+
+		hostSet = append(hostSet, u.Host)
+	}
+
+	sort.Strings(hostSet)
+	return hostSet, nil
 }

--- a/modules/gloo/pkg/vsfactory/vsfactory.go
+++ b/modules/gloo/pkg/vsfactory/vsfactory.go
@@ -4,10 +4,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/retries"
-
 	rioadminv1controller "github.com/rancher/rio/pkg/generated/controllers/admin.rio.cattle.io/v1"
 	"github.com/rancher/rio/types"
+	corev1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
 	extensionsv1beta1controller "github.com/rancher/wrangler-api/pkg/generated/controllers/extensions/v1beta1"
 	"github.com/rancher/wrangler/pkg/name"
 	soloapiv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
@@ -16,6 +15,7 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/headers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/retries"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,6 +35,7 @@ type VirtualServiceFactory struct {
 	clusterDomainCache rioadminv1controller.ClusterDomainCache
 	publicDomainCache  rioadminv1controller.PublicDomainCache
 	ingresses          extensionsv1beta1controller.IngressCache
+	endpoints          corev1.EndpointsCache
 	systemNamespace    string
 }
 
@@ -44,6 +45,7 @@ func New(rContext *types.Context) *VirtualServiceFactory {
 		publicDomainCache:  rContext.Admin.Admin().V1().PublicDomain().Cache(),
 		systemNamespace:    rContext.Namespace,
 		ingresses:          rContext.K8sNetworking.Extensions().V1beta1().Ingress().Cache(),
+		endpoints:          rContext.Core.Core().V1().Endpoints().Cache(),
 	}
 }
 


### PR DESCRIPTION
Address 'no healthy upstream' by ensuring service has allocated corev1.Endpoint IP

https://github.com/rancher/rio/issues/607
https://github.com/rancher/rio/issues/584
https://github.com/rancher/rio/issues/861