### PR TITLE
cli utils bug with namespace-in-name

### DIFF
--- a/cli/cmd/stage/stage.go
+++ b/cli/cmd/stage/stage.go
@@ -130,7 +130,7 @@ func (r *Stage) stageService(ctx *clicontext.CLIContext, service types.Resource,
 // if no weight is set on this app's svcs (ignoring new staged service) then assign them all equally to PromoteWeight
 func (r *Stage) updatePreviousServiceWeights(ctx *clicontext.CLIContext, service types.Resource, version string) error {
 	var allErrors []error
-	svcs, err := util.ListAppServicesFromServiceName(ctx, service.Name)
+	svcs, err := util.ListAppServicesFromAppName(ctx, service.Namespace, service.App)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/util/service.go
+++ b/cli/cmd/util/service.go
@@ -7,19 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ListAppServicesFromServiceName(ctx *clicontext.CLIContext, serviceName string) ([]*riov1.Service, error) {
-	namespace := ctx.GetSetNamespace()
-	service, err := ctx.ByID(serviceName)
-	if err != nil {
-		return nil, err
-	}
-
-	svc := service.Object.(*riov1.Service)
-	app, _ := services.AppAndVersion(svc)
-	return ListAppServicesFromAppName(ctx, namespace, app)
-
-}
-
 func ListAppServicesFromAppName(ctx *clicontext.CLIContext, namespace, appName string) ([]*riov1.Service, error) {
 	svcs, err := ctx.Rio.Services(namespace).List(metav1.ListOptions{})
 	if err != nil {

--- a/tests/integration/stage_test.go
+++ b/tests/integration/stage_test.go
@@ -51,6 +51,27 @@ func stageTests(t *testing.T, when spec.G, it spec.S) {
 	when("a running service has a version staged with the run command", func() {
 
 		it.Before(func() {
+			service.Create(t, "--weight", "100", "ibuildthecloud/demo:v1")
+		})
+
+		it.After(func() {
+			service.Remove()
+			stagedService.Remove()
+		})
+
+		it("should have proper fields assigned", func() {
+			stagedService = service.StageRun("ibuildthecloud/demo:v3", "v3", "80", "50")
+			stageName := fmt.Sprintf("%s@%s", service.App, "v3")
+			assert.Equal(t, stageName, stagedService.Name, "should have correct name")
+			assert.Equal(t, service.App, stagedService.App, "should have same app")
+			assert.Equal(t, 10000, stagedService.GetSpecWeight(), "should have weight set to 50%") // 10k is to match other 10k at 50%
+		})
+	}, spec.Parallel())
+
+	when("a running service has a version staged with the namespaced syntax", func() {
+		stageVersion := "v3"
+
+		it.Before(func() {
 			service.Create(t, "ibuildthecloud/demo:v1")
 		})
 
@@ -60,11 +81,9 @@ func stageTests(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("should have proper fields assigned", func() {
-			stagedService = service.RunStage("ibuildthecloud/demo:v3", "v3", "80", "50")
-			stageName := fmt.Sprintf("%s@%s", service.App, "v3")
+			stagedService = service.StageExec("ibuildthecloud/demo:v3", stageVersion)
+			stageName := fmt.Sprintf("%s@%s", service.App, stageVersion)
 			assert.Equal(t, stageName, stagedService.Name, "should have correct name")
-			assert.Equal(t, service.App, stagedService.App, "should have same app")
-			assert.Equal(t, 10000, stagedService.GetSpecWeight(), "should have weight set") // 10k is to match other 10k at 50%
 		})
 	}, spec.Parallel())
 }

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -61,6 +61,11 @@ func ValidationPreCheck() {
 // Example: args=["run", "-n", "test", "nginx"] would run: "rio --namespace testing-namespace run -n test nginx"
 func RioCmd(args []string, envs ...string) (string, error) {
 	args = append([]string{"--namespace", TestingNamespace}, args...)
+	return RioExecute(args, envs...)
+}
+
+// RioExecute executes rio CLI commands with arguments, use RioCmd unless you have to use a non-testing namespace
+func RioExecute(args []string, envs ...string) (string, error) {
 	cmd := exec.Command("rio", args...)
 	cmd.Env = envs
 	stdOutErr, err := cmd.CombinedOutput()
@@ -81,7 +86,7 @@ func RioCmdWithRetry(args []string, envs ...string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%s: %s", err.Error(), out)
 	}
-	return string(out), nil
+	return out, nil
 }
 
 // RioCmdWithTail executes rio CLI commands that tail output with your arguments in testing namespace.


### PR DESCRIPTION
Issue: https://github.com/rancher/rio/issues/993

The `ListAppServicesFromServiceName` is incorrect because it won't take into account namespace-in-name, and redundant because `ListAppServicesFromAppName` gives you same data. 