### PR TITLE
Edit help/usage to be more consistent and contain examples

### DIFF
--- a/cli/cmd/buildhistory/buildhistory.go
+++ b/cli/cmd/buildhistory/buildhistory.go
@@ -18,7 +18,7 @@ func History(app *cli.App) cli.Command {
 		"")
 	return cli.Command{
 		Name:   "build-history",
-		Usage:  "Show build-history",
+		Usage:  "Show build history",
 		Action: clicontext.DefaultAction(hist.Action),
 		Flags:  table.WriterFlags(),
 	}

--- a/cli/cmd/builds/build.go
+++ b/cli/cmd/builds/build.go
@@ -20,7 +20,7 @@ func Builds(app *cli.App) cli.Command {
 	build := builder.Command(&Build{},
 		"Build docker image using buildkitd",
 		app.Name+" build [OPTIONS] PATH",
-		"")
+		"Example: run `rio build .` in a directory containing Dockerfile")
 	return build
 }
 

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -34,9 +34,9 @@ func Config(app *cli.App) cli.Command {
 				"Create a config from a file or stdin (with `-` argument)",
 				app.Name+" config create [-k KEY] [NAMESPACE:]NAME FILE|-",
 				"Example: Set key `hostname` in config map `webapp` to output of command:\n"+
-        "         `echo example.com | rio config create -k hostname webapp -`\n"+
-        "         Set key `json_config` of config map `app` to content of config.json file:\n"+
-        "         `rio config create -k json_config app ./config.json`"),
+					"         `echo example.com | rio config create -k hostname webapp -`\n"+
+					"         Set key `json_config` of config map `app` to content of config.json file:\n"+
+					"         `rio config create -k json_config app ./config.json`"),
 			builder.Command(&Ls{},
 				"List configs",
 				app.Name+" config ls",

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -13,7 +13,7 @@ func NewCatCommand(sub string, app *cli.App) cli.Command {
 	return builder.Command(&Cat{},
 		"Print the contents of a config",
 		app.Name+sub+" cat [OPTIONS] [NAME...]",
-		fmt.Sprintf("To cat all keys, run `rio cat [NAMESPACE:]configmap/NAME. To cat specific keys, run `rio cat --key foo --key bar configmap/NAME"))
+		fmt.Sprintf("To cat all keys, run `rio cat [NAMESPACE:]configmap/NAME`. To cat specific keys, run `rio cat --key foo --key bar configmap/NAME`"))
 }
 
 func Config(app *cli.App) cli.Command {
@@ -48,7 +48,7 @@ func Config(app *cli.App) cli.Command {
 			builder.Command(&Update{},
 				"Update a config",
 				app.Name+" config update [-k KEY] [NAMESPACE:]TYPE/NAME FILE|-",
-				"Example: run `rio config update configmap/mysql"),
+				"Example: run `rio config update configmap/mysql`"),
 		},
 	}
 }

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -13,7 +13,7 @@ func NewCatCommand(sub string, app *cli.App) cli.Command {
 	return builder.Command(&Cat{},
 		"Print the contents of a config",
 		app.Name+sub+" cat [OPTIONS] [NAME...]",
-		fmt.Sprintf("To cat all keys, run `rio cat [$NAMESPACE/]$NAME. To cat specific keys, run `rio cat --key foo --key bar [$NAMESPACE/]$NAME"))
+		fmt.Sprintf("To cat all keys, run `rio cat [NAMESPACE:]configmap/NAME. To cat specific keys, run `rio cat --key foo --key bar configmap/NAME"))
 }
 
 func Config(app *cli.App) cli.Command {
@@ -31,21 +31,24 @@ func Config(app *cli.App) cli.Command {
 		Subcommands: []cli.Command{
 			NewCatCommand(" config", app),
 			builder.Command(&Create{},
-				"Create a config from a file",
-				app.Name+" config create NAME FILE|-",
-				""),
+				"Create a config from a file or stdin (with `-` argument)",
+				app.Name+" config create [-k KEY] [NAMESPACE:]NAME FILE|-",
+				"Example: Set key `hostname` in config map `webapp` to output of command:\n"+
+        "         `echo example.com | rio config create -k hostname webapp -`\n"+
+        "         Set key `json_config` of config map `app` to content of config.json file:\n"+
+        "         `rio config create -k json_config app ./config.json`"),
 			builder.Command(&Ls{},
 				"List configs",
 				app.Name+" config ls",
 				""),
 			builder.Command(&Rm{},
 				"Remove a config",
-				app.Name+" config rm [NAME...]",
-				""),
+				app.Name+" config rm [NAMESPACE:][TYPE/NAME...]",
+				"Example: run `rio config rm configmap/mysql`"),
 			builder.Command(&Update{},
 				"Update a config",
-				app.Name+" config update NAME FILE|-",
-				""),
+				app.Name+" config update [-k KEY] [NAMESPACE:]TYPE/NAME FILE|-",
+				"Example: run `rio config update configmap/mysql"),
 		},
 	}
 }

--- a/cli/cmd/externalservice/externalservice.go
+++ b/cli/cmd/externalservice/externalservice.go
@@ -11,9 +11,9 @@ func ExternalService(app *cli.App) cli.Command {
 	create := builder.Command(&Create{},
 		"Create external services",
 		app.Name+" external create [EXTERNAL_SERVICE] [(IP)(FQDN)(SERVICE/APP/ROUTER)]",
-		"To create an externalservice by pointing to FQDN, run `rio external create [$NAMESPACE:]$NAME foo.bar.\n"+
-			"	 To create an externalservice by pointing to IPs, run `rio external create [$NAMESPACE:]$NAME 1.1.1.1 2.2.2.2.\n"+
-			"	 To create an externalservice by pointing to service/router in another namespace, run `rio external create [$NAMESPACE:]$NAME [$namespace:]@name`")
+		"To create an externalservice by pointing to FQDN, run `rio external create [NAMESPACE:]NAME foo.bar.\n"+
+			"	 To create an externalservice by pointing to IPs, run `rio external create [NAMESPACE:]NAME 1.1.1.1 2.2.2.2.\n"+
+			"	 To create an externalservice by pointing to service/router in another namespace, run `rio external create [NAMESPACE:]NAME [NAMESPACE:]@NAME`")
 	ls := builder.Command(&Ls{},
 		"List external services",
 		app.Name+" external ls",
@@ -21,7 +21,7 @@ func ExternalService(app *cli.App) cli.Command {
 	rm := builder.Command(&Rm{},
 		"Remove external services",
 		app.Name+" external rm [EXTERNAL_SERVICE]",
-		"")
+		"Example: run `rio external rm externalservice/redis`")
 	rm.Aliases = []string{"delete"}
 	return cli.Command{
 		Name:      "externalservices",

--- a/cli/cmd/publicdomain/publicdomain.go
+++ b/cli/cmd/publicdomain/publicdomain.go
@@ -13,12 +13,12 @@ func PublicDomain(app *cli.App) cli.Command {
 		"")
 	register := builder.Command(&Register{},
 		"Register public domains",
-		app.Name+" domain register $NAME $NAMESPACE/$SERVICE",
+		app.Name+" domain register NAME [NAMESPACE:]SERVICE",
 		"Example: run `rio domain register foo.bar [namespace:][service_or_router][@version]`")
 	unregister := builder.Command(&Unregister{},
-		"Unregister public domains",
-		app.Name+" domain unregister $NAME",
-		"")
+		"Unregister public domains.",
+		app.Name+" domain unregister TYPE/NAME",
+		"Example: run `rio domain unregister publicdomain/foo.bar`")
 	return cli.Command{
 		Name:      "domains",
 		ShortName: "domain",

--- a/cli/cmd/route/route.go
+++ b/cli/cmd/route/route.go
@@ -11,7 +11,7 @@ func Route(app *cli.App) cli.Command {
 	create := builder.Command(&Create{},
 		"Create a router at the end",
 		app.Name+" router create/add MATCH ACTION [TARGET...]",
-		"To append a rule at the end, run `rio [-n $NAMESPACE] router add $ROUTE_NAME to|redirect|mirror|rewrite $APP[@VERSION]. If version not specified app is assumed.")
+		"To append a rule at the end, run `rio router add $ROUTE_NAME to|redirect|mirror|rewrite $APP[@VERSION]. If version not specified app is assumed.")
 	create.Aliases = []string{"add"}
 	ls := builder.Command(&Ls{},
 		"List router",

--- a/cli/cmd/route/route.go
+++ b/cli/cmd/route/route.go
@@ -11,7 +11,7 @@ func Route(app *cli.App) cli.Command {
 	create := builder.Command(&Create{},
 		"Create a router at the end",
 		app.Name+" router create/add MATCH ACTION [TARGET...]",
-		"To append a rule at the end, run `rio router add $ROUTE_NAME to|redirect|mirror|rewrite $APP[@VERSION]. If version not specified app is assumed.")
+		"To append a rule at the end, run `rio router add $ROUTE_NAME to|redirect|mirror|rewrite $APP[@VERSION]`. If version not specified app is assumed.")
 	create.Aliases = []string{"add"}
 	ls := builder.Command(&Ls{},
 		"List router",

--- a/cli/cmd/secrets/secret.go
+++ b/cli/cmd/secrets/secret.go
@@ -24,7 +24,7 @@ func Secrets(app *cli.App) cli.Command {
 		Flags:     create.Flags,
 		Category:  "SUB COMMANDS",
 		Subcommands: []cli.Command{
-      ls,
+			ls,
 			create,
 		},
 	}

--- a/cli/cmd/secrets/secret.go
+++ b/cli/cmd/secrets/secret.go
@@ -9,12 +9,12 @@ import (
 func Secrets(app *cli.App) cli.Command {
 	create := builder.Command(&Create{},
 		"Create Secrets",
-		app.Name+" secrets create [OPTIONS] $Name",
+		app.Name+" secrets create [OPTIONS] NAME",
 		"")
 	create.Aliases = []string{"add"}
 	ls := builder.Command(&Ls{},
 		"List Secrets",
-		app.Name+" secrets ls [OPTIONS] $Name",
+		app.Name+" secrets ls",
 		"")
 	return cli.Command{
 		Name:      "secrets",
@@ -24,6 +24,7 @@ func Secrets(app *cli.App) cli.Command {
 		Flags:     create.Flags,
 		Category:  "SUB COMMANDS",
 		Subcommands: []cli.Command{
+      ls,
 			create,
 		},
 	}

--- a/cli/cmd/stacks/stack.go
+++ b/cli/cmd/stacks/stack.go
@@ -9,11 +9,11 @@ import (
 func Stacks(app *cli.App) cli.Command {
 	ls := builder.Command(&ls{},
 		"List stacks",
-		app.Name+" stack ls [OPTIONS] $Name",
+		app.Name+" stack ls",
 		"")
 	info := builder.Command(&info{},
 		"describe general information for stack",
-		app.Name+" stack info $NAME",
+		app.Name+" stack info NAME",
 		"")
 	update := builder.Command(&update{},
 		"Update stack answers and images",

--- a/cli/main.go
+++ b/cli/main.go
@@ -153,7 +153,7 @@ func main() {
 			"Export a namespace or service",
 			appName+" export [TYPE/]RESOURCE_OR_SERVICE_NAME",
 			"Example: `rio export postgresql@3d0f6e23`\n"+
-      "         `rio export configmap/test`"),
+				"         `rio export configmap/test`"),
 
 		builder.Command(&images.Images{},
 			"List images built from local registry",

--- a/cli/main.go
+++ b/cli/main.go
@@ -146,13 +146,14 @@ func main() {
 
 		builder.Command(&exec.Exec{},
 			"Run a command in a running container",
-			appName+" exec [OPTIONS] CONTAINER COMMAND [ARG...]",
+			appName+" exec [OPTIONS] SERVICE COMMAND [ARG...]",
 			""),
 
 		builder.Command(&export.Export{},
 			"Export a namespace or service",
-			appName+" export [TYPE/]NAMESPACE_OR_SERVICE",
-			""),
+			appName+" export [TYPE/]RESOURCE_OR_SERVICE_NAME",
+			"Example: `rio export postgresql@3d0f6e23`\n"+
+      "         `rio export configmap/test`"),
 
 		builder.Command(&images.Images{},
 			"List images built from local registry",
@@ -173,7 +174,7 @@ func main() {
 
 		builder.Command(&kill.Kill{},
 			"Kill pods individually or all pods belonging to a service",
-			appName+" kill [SERVICE_NAME/POD_NAME]",
+			appName+" kill SERVICE_NAME[/POD_NAME]",
 			"Specify a SERVICE_NAME to kill all pods belonging to that service. Otherwise specify a POD_NAME"),
 
 		builder.Command(&linkerd.Linkerd{},
@@ -218,7 +219,7 @@ func main() {
 
 		builder.Command(&uninstall.Uninstall{},
 			"Uninstall rio",
-			appName+" uninstall [OPTIONS]",
+			appName+" uninstall",
 			""),
 
 		builder.Command(&up.Up{},


### PR DESCRIPTION
This patch contains edits / fixes to rio help / usage system.
Beware, I am not a go programmer; I tried not to break the syntax but I do not know it nor style best practices.

Why's:
- everywhere where I encountered a $FOO or $Foo placeholder, I replaced it with FOO
- build-history - use phrase "build history" with a space in usage.
- config - specify that configmap/ must be prefixed to name. Using NAMESPACE/NAME does not work. One needs to do
- route - removed the `-n NAMESPACE` because this applies to all commands
- secret - the subcommand `ls` does not accept options nor arguments, do not state otherwise
- exec - changed CONTAINER to SERVICE because the argument is what `rio ps` displays, what seems to be called a SERVICE. The container can be specified by `-c` option
- uninstall - does not accept options

Last but not least, **thank you for amazing work** :heart:. I've been a fan since Rancher 1!