### PR TITLE
Add bash/zsh completion

### DIFF
--- a/cli/autocomplete/bash_autocomplete
+++ b/cli/autocomplete/bash_autocomplete
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur" == "-"* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/cli/autocomplete/zsh_autocomplete
+++ b/cli/autocomplete/zsh_autocomplete
@@ -1,0 +1,13 @@
+#compdef $PROG
+
+_cli_zsh_autocomplete() {
+
+  local -a opts
+  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+
+  _describe 'values' opts
+
+  return
+}
+
+compdef _cli_zsh_autocomplete $PROG

--- a/cli/main.go
+++ b/cli/main.go
@@ -71,6 +71,7 @@ func main() {
 	app.Name = appName
 	app.Usage = "Containers made simple, as they should be"
 	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
+	app.EnableBashCompletion = true
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Printf("%s version %s\n", app.Name, app.Version)
 	}


### PR DESCRIPTION
This PR enables shell completion via urfav
In order to use it, you must source the correct shell completion script
in cli/autocomplete/ with the env variable PROG=rio.
For example, 
`PROG=rio source $RIO_REPO_ROOT/cli/autocomplete/bash_autocomplete`

There is still more to be done in order to make this consumable by end
users.