### PR TITLE
Fix documentation

### DIFF
--- a/docs/publicdomain-external-services.md
+++ b/docs/publicdomain-external-services.md
@@ -67,7 +67,7 @@ $ rio domain register  myproductionsite.com router/prod
 To unregister a domain:
 
 ```bash
-$ rio unregister publicdomain/myproductionsite.com 
+$ rio domain unregister publicdomain/myproductionsite.com 
 ```
 
 ## ExternalService


### PR DESCRIPTION
The command to unregister a public domain is `rio domain unregister`, not `rio unregister` as the document currently says.