### PR TITLE
fix documentation of ServiceMesh property

### DIFF
--- a/pkg/apis/rio.cattle.io/v1/service_types.go
+++ b/pkg/apis/rio.cattle.io/v1/service_types.go
@@ -111,7 +111,7 @@ type ServiceSpec struct {
 	// Place one pod per node that matches the scheduling rules
 	Global bool `json:"global,omitempty"`
 
-	// Whether to disable Service mesh for the Service. If true, no mesh sidecar will be deployed along with the Service
+	// Whether to disable Service mesh for the Service. If false, no mesh sidecar will be deployed along with the Service
 	ServiceMesh *bool `json:"serviceMesh,omitempty"`
 
 	// RequestTimeoutSeconds specifies the timeout set on api gateway for each individual service


### PR DESCRIPTION
In my testing, `serviceMesh: false` was required in order to disable the linkerd sidecar for the service.

At the time of my test, my rio-config configmap contained:

```
    "linkerd": {
      "enabled": true,
      "description": "linkerd service mesh"
    },
```